### PR TITLE
Spark DataFrame insert into Exasol Table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,19 +45,19 @@ matrix:
   include:
     - jdk: openjdk8
       scala: 2.11.12
-      env: SPARK_VERSION="2.1.0"
+      env: SPARK_VERSION="2.3.2"
 
     - jdk: oraclejdk8
       scala: 2.11.12
-      env: SPARK_VERSION="2.1.0"
+      env: SPARK_VERSION="2.3.2"
 
     - jdk: openjdk8
       scala: 2.11.12
-      env: SPARK_VERSION="2.3.1"
+      env: SPARK_VERSION="2.4.0"
 
     - jdk: oraclejdk8
       scala: 2.11.12
-      env: SPARK_VERSION="2.3.1" RELEASE=false
+      env: SPARK_VERSION="2.4.0" RELEASE=false
 
 script:
   - travis_wait 30 ./scripts/ci.sh

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ For more examples you can check [docs/examples](docs/examples.md).
 You can include the connector as a dependency in your projects. Please find the
 latest versions at [Maven Central
 Repositories](https://mvnrepository.com/artifact/com.exasol) for
-`spark-connector`
+`spark-connector`.
 
 Using SBT:
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,12 +8,12 @@ object Dependencies {
   // Versions
   private val SparkVersion = "2.4.0"
   private val ExasolJdbcVersion = "6.0.13"
-  private val TypesafeLoggingVersion = "3.7.2"
+  private val TypesafeLoggingVersion = "3.9.0"
 
   private val ScalaTestVersion = "3.0.5"
   private val MockitoVersion = "2.23.4"
-  private val ContainersJdbcVersion = "1.10.3"
-  private val ContainersScalaVersion = "0.19.0"
+  private val ContainersJdbcVersion = "1.10.5"
+  private val ContainersScalaVersion = "0.22.0"
 
   private val sparkCurrentVersion =
     sys.props.get("spark.currentVersion").getOrElse(SparkVersion)

--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -34,6 +34,12 @@ object Publishing {
     ),
     developers := List(
       Developer(
+        id = "exasol",
+        name = "Exasol AG",
+        email = "opensource@exasol.com",
+        url = url("https://github.com/exasol/")
+      ),
+      Developer(
         id = "morazow",
         name = "Muhammet Orazov",
         email = "muhammet.orazov@exasol.com",

--- a/src/it/scala/com/exasol/spark/BaseDockerSuite.scala
+++ b/src/it/scala/com/exasol/spark/BaseDockerSuite.scala
@@ -22,79 +22,71 @@ trait BaseDockerSuite extends ForAllTestContainer { self: Suite =>
   val EXA_ALL_TYPES_TABLE = "TEST_ALL_TYPES_TABLE"
   val EXA_TYPES_NOT_COVERED_TABLE = "TEST_TYPES_NOT_COVERED_TABLE"
 
-  def runExaQuery(queries: Seq[String]): Unit =
-    exaManager.withConnection[Unit] { conn =>
-      queries.foreach(conn.createStatement.execute(_))
-      ()
-    }
-
-  def runExaQuery(queryString: String): Unit =
-    runExaQuery(Seq(queryString))
-
-  // scalastyle:off
+  // scalastyle:off nonascii
   def createDummyTable(): Unit = {
-    runExaQuery(s"DROP SCHEMA IF EXISTS $EXA_SCHEMA CASCADE")
-    runExaQuery(s"CREATE SCHEMA $EXA_SCHEMA")
-    runExaQuery(s"""
-                   |CREATE OR REPLACE TABLE $EXA_SCHEMA.$EXA_TABLE (
-                   |   ID INTEGER IDENTITY NOT NULL,
-                   |   NAME VARCHAR(100) UTF8,
-                   |   CITY VARCHAR(2000) UTF8,
-                   |   DATE_INFO DATE,
-                   |   UPDATED_AT TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-                   |   UNICODE_COL VARCHAR(100) UTF8
-                   |)""".stripMargin)
-    runExaQuery(s"""
-                   |INSERT INTO $EXA_SCHEMA.$EXA_TABLE (name, city, date_info, unicode_col)
-                   | VALUES ('Germany', 'Berlin', '2017-12-31', 'öäüß')
-                   | """.stripMargin)
-    runExaQuery(s"""
-                   |INSERT INTO $EXA_SCHEMA.$EXA_TABLE (name, city, date_info, unicode_col)
-                   | VALUES ('France', 'Paris', '2018-01-01','\u00d6')
-                   | """.stripMargin)
-    runExaQuery(s"""
-                   |INSERT INTO $EXA_SCHEMA.$EXA_TABLE (name, city, date_info, unicode_col)
-                   | VALUES ('Portugal', 'Lisbon', '2018-10-01','\u00d9')
-                   | """.stripMargin)
-    runExaQuery("commit")
+    val queries = Seq(
+      s"DROP SCHEMA IF EXISTS $EXA_SCHEMA CASCADE",
+      s"CREATE SCHEMA $EXA_SCHEMA",
+      s"""|CREATE OR REPLACE TABLE $EXA_SCHEMA.$EXA_TABLE (
+          |   ID INTEGER IDENTITY NOT NULL,
+          |   NAME VARCHAR(100) UTF8,
+          |   CITY VARCHAR(2000) UTF8,
+          |   DATE_INFO DATE,
+          |   UPDATED_AT TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+          |   UNICODE_COL VARCHAR(100) UTF8
+          |)""".stripMargin,
+      s"""|INSERT INTO $EXA_SCHEMA.$EXA_TABLE (name, city, date_info, unicode_col)
+          | VALUES ('Germany', 'Berlin', '2017-12-31', 'öäüß')
+          |""".stripMargin,
+      s"""|INSERT INTO $EXA_SCHEMA.$EXA_TABLE (name, city, date_info, unicode_col)
+          | VALUES ('France', 'Paris', '2018-01-01','\u00d6')
+          |""".stripMargin,
+      s"""|INSERT INTO $EXA_SCHEMA.$EXA_TABLE (name, city, date_info, unicode_col)
+          | VALUES ('Portugal', 'Lisbon', '2018-10-01','\u00d9')
+          |""".stripMargin,
+      "commit"
+    )
+    exaManager.withExecute(queries)
   }
-  // scalastyle:on
+  // scalastyle:on nonascii
 
   def createAllTypesTable(): Unit = {
-    runExaQuery(s"DROP SCHEMA IF EXISTS $EXA_SCHEMA CASCADE")
-    runExaQuery(s"CREATE SCHEMA $EXA_SCHEMA")
     val maxDecimal = " DECIMAL(" + getMaxPrecisionExasol() + "," + getMaxScaleExasol() + ")"
-    runExaQuery(
-      s"""
-         |CREATE OR REPLACE TABLE $EXA_SCHEMA.$EXA_ALL_TYPES_TABLE (
-         |   MYID INTEGER,
-         |   MYTINYINT DECIMAL(3,0),
-         |   MYSMALLINT DECIMAL(9,0),
-         |   MYBIGINT DECIMAL(36,0),
-         |   MYDECIMALSystemDefault DECIMAL,
-         |   MYDECIMALMAX $maxDecimal,
-         |   MYNUMERIC DECIMAL( 5,2 ),
-         |   MYDOUBLE DOUBLE PRECISION,
-         |   MYCHAR CHAR,
-         |   MYNCHAR CHAR(2000),
-         |   MYLONGVARCHAR VARCHAR( 2000000),
-         |   MYBOOLEAN BOOLEAN,
-         |   MYDATE DATE,
-         |   MYTIMESTAMP TIMESTAMP,
-         |   MYGEOMETRY Geometry)""".stripMargin
+    val queries = Seq(
+      s"DROP SCHEMA IF EXISTS $EXA_SCHEMA CASCADE",
+      s"CREATE SCHEMA $EXA_SCHEMA",
+      s"""|CREATE OR REPLACE TABLE $EXA_SCHEMA.$EXA_ALL_TYPES_TABLE (
+          |   MYID INTEGER,
+          |   MYTINYINT DECIMAL(3,0),
+          |   MYSMALLINT DECIMAL(9,0),
+          |   MYBIGINT DECIMAL(36,0),
+          |   MYDECIMALSystemDefault DECIMAL,
+          |   MYDECIMALMAX $maxDecimal,
+          |   MYNUMERIC DECIMAL( 5,2 ),
+          |   MYDOUBLE DOUBLE PRECISION,
+          |   MYCHAR CHAR,
+          |   MYNCHAR CHAR(2000),
+          |   MYLONGVARCHAR VARCHAR( 2000000),
+          |   MYBOOLEAN BOOLEAN,
+          |   MYDATE DATE,
+          |   MYTIMESTAMP TIMESTAMP,
+          |   MYGEOMETRY Geometry
+          |)""".stripMargin,
+      "commit"
     )
-    runExaQuery("commit")
+    exaManager.withExecute(queries)
   }
 
-  def createTypesNotCoveredTable(): Unit = {
-    runExaQuery(s"DROP SCHEMA IF EXISTS $EXA_SCHEMA CASCADE")
-    runExaQuery(s"CREATE SCHEMA $EXA_SCHEMA")
-    runExaQuery(
-      s"""
-         |CREATE OR REPLACE TABLE $EXA_SCHEMA.$EXA_TYPES_NOT_COVERED_TABLE (
-         |   myInterval INTERVAL YEAR TO MONTH )""".stripMargin
+  def createTypesNotCoveredTable(): Unit =
+    exaManager.withExecute(
+      Seq(
+        s"DROP SCHEMA IF EXISTS $EXA_SCHEMA CASCADE",
+        s"CREATE SCHEMA $EXA_SCHEMA",
+        s"""|CREATE OR REPLACE TABLE $EXA_SCHEMA.$EXA_TYPES_NOT_COVERED_TABLE (
+            |   myInterval INTERVAL YEAR TO MONTH
+            |)""".stripMargin,
+        "commit"
+      )
     )
-    runExaQuery("commit")
-  }
 
 }

--- a/src/it/scala/com/exasol/spark/BaseDockerSuite.scala
+++ b/src/it/scala/com/exasol/spark/BaseDockerSuite.scala
@@ -32,8 +32,8 @@ trait BaseDockerSuite extends ForAllTestContainer { self: Suite =>
           |   NAME VARCHAR(100) UTF8,
           |   CITY VARCHAR(2000) UTF8,
           |   DATE_INFO DATE,
-          |   UPDATED_AT TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-          |   UNICODE_COL VARCHAR(100) UTF8
+          |   UNICODE_COL VARCHAR(100) UTF8,
+          |   UPDATED_AT TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
           |)""".stripMargin,
       s"""|INSERT INTO $EXA_SCHEMA.$EXA_TABLE (name, city, date_info, unicode_col)
           | VALUES ('Germany', 'Berlin', '2017-12-31', 'öäüß')

--- a/src/it/scala/com/exasol/spark/LoadSuite.scala
+++ b/src/it/scala/com/exasol/spark/LoadSuite.scala
@@ -82,7 +82,7 @@ class LoadSuite extends FunSuite with BaseDockerSuite with DataFrameSuiteBase {
         .load()
     }
     assert(
-      thrown.getMessage === "A sql query string should be specified when loading from Exasol"
+      thrown.getMessage === "A query parameter should be specified in order to run the operation"
     )
   }
 
@@ -186,9 +186,7 @@ class LoadSuite extends FunSuite with BaseDockerSuite with DataFrameSuiteBase {
       .load()
 
     assert(df.count() === 3)
-    // scalastyle:off
-    assert(df.collect().map(_(0)).toSet === Set("öäüß", "Ö", "Ù"))
-    // scalastyle:on
+    assert(df.collect().map(_(0)).toSet === Set("öäüß", "Ö", "Ù")) // scalastyle:ignore nonascii
   }
 
 }

--- a/src/it/scala/com/exasol/spark/ReservedKeywordsSuite.scala
+++ b/src/it/scala/com/exasol/spark/ReservedKeywordsSuite.scala
@@ -53,18 +53,20 @@ class ReservedKeywordsSuite extends FunSuite with BaseDockerSuite with DataFrame
     assert(df.collect().map(x => x(0)).toSet === Set("Checked"))
   }
 
-  def createTable(): Unit = {
-    runExaQuery(s"DROP SCHEMA IF EXISTS $SCHEMA CASCADE")
-    runExaQuery(s"CREATE SCHEMA $SCHEMA")
-    runExaQuery(s"""
-                   |CREATE OR REPLACE TABLE $SCHEMA.$TABLE (
-                   |   ID INTEGER IDENTITY NOT NULL,
-                   |   "CONDITION" VARCHAR(100) UTF8
-                   |)""".stripMargin)
-    runExaQuery(s"""INSERT INTO $SCHEMA.$TABLE ("CONDITION") VALUES ('True')""")
-    runExaQuery(s"""INSERT INTO $SCHEMA.$TABLE ("CONDITION") VALUES ('False')""")
-    runExaQuery(s"""INSERT INTO $SCHEMA.$TABLE ("CONDITION") VALUES ('Checked')""")
-    runExaQuery("commit")
-  }
+  def createTable(): Unit =
+    exaManager.withExecute(
+      Seq(
+        s"DROP SCHEMA IF EXISTS $SCHEMA CASCADE",
+        s"CREATE SCHEMA $SCHEMA",
+        s"""|CREATE OR REPLACE TABLE $SCHEMA.$TABLE (
+            |   ID INTEGER IDENTITY NOT NULL,
+            |   "CONDITION" VARCHAR(100) UTF8
+            |)""".stripMargin,
+        s"""INSERT INTO $SCHEMA.$TABLE ("CONDITION") VALUES ('True')""",
+        s"""INSERT INTO $SCHEMA.$TABLE ("CONDITION") VALUES ('False')""",
+        s"""INSERT INTO $SCHEMA.$TABLE ("CONDITION") VALUES ('Checked')""",
+        "commit"
+      )
+    )
 
 }

--- a/src/it/scala/com/exasol/spark/SaveSuite.scala
+++ b/src/it/scala/com/exasol/spark/SaveSuite.scala
@@ -1,0 +1,33 @@
+package com.exasol.spark
+
+import org.apache.spark.{SparkConf, SparkException}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types._
+
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
+import org.scalatest.FunSuite
+
+/** Integration tests for saving Spark dataframes into Exasol tables */
+class SaveSuite extends FunSuite with BaseDockerSuite with DataFrameSuiteBase {
+
+  test("`tableExists` should return correct boolean result") {
+    createDummyTable()
+
+    assert(exaManager.tableExists(s"$EXA_SCHEMA.$EXA_TABLE") === true)
+    assert(exaManager.tableExists("DUMMY_SCHEMA.DUMMYTABLE") === false)
+  }
+
+  test("`tuncateTable` should perform table truncation") {
+    createDummyTable()
+
+    assert(exaManager.withCountQuery(s"SELECT COUNT(*) FROM $EXA_SCHEMA.$EXA_TABLE") > 0)
+
+    exaManager.truncateTable(s"$EXA_SCHEMA.$EXA_TABLE")
+    assert(exaManager.withCountQuery(s"SELECT COUNT(*) FROM $EXA_SCHEMA.$EXA_TABLE") === 0)
+
+    // Idempotent
+    exaManager.truncateTable(s"$EXA_SCHEMA.$EXA_TABLE")
+    assert(exaManager.withCountQuery(s"SELECT COUNT(*) FROM $EXA_SCHEMA.$EXA_TABLE") === 0)
+  }
+
+}

--- a/src/it/scala/com/exasol/spark/SaveSuite.scala
+++ b/src/it/scala/com/exasol/spark/SaveSuite.scala
@@ -1,5 +1,7 @@
 package com.exasol.spark
 
+import java.sql.Date
+
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types._
@@ -28,6 +30,59 @@ class SaveSuite extends FunSuite with BaseDockerSuite with DataFrameSuiteBase {
     // Idempotent
     exaManager.truncateTable(s"$EXA_SCHEMA.$EXA_TABLE")
     assert(exaManager.withCountQuery(s"SELECT COUNT(*) FROM $EXA_SCHEMA.$EXA_TABLE") === 0)
+  }
+
+  // scalastyle:off nonascii
+  val testData: Seq[(String, String, Date, String)] = Seq(
+    ("name1", "city1", Date.valueOf("2019-01-11"), "äpişge"),
+    ("name1", "city2", Date.valueOf("2019-01-12"), "gül"),
+    ("name2", "city1", Date.valueOf("2019-02-25"), "çigit"),
+    ("name2", "city2", Date.valueOf("2019-02-25"), "okay")
+  )
+  // scalastyle:on
+
+  def runWithSaveMode(mode: String, partitionCnt: Int): Long = {
+    import sqlContext.implicits._
+    createDummyTable()
+
+    val df = sc
+      .parallelize(testData, partitionCnt)
+      .toDF("name", "city", "date_info", "unicode_col")
+
+    df.write
+      .mode(mode)
+      .option("host", container.host)
+      .option("port", s"${container.port}")
+      .option("table", s"$EXA_SCHEMA.$EXA_TABLE")
+      .format("exasol")
+      .save()
+
+    exaManager.withCountQuery(s"SELECT COUNT(*) FROM $EXA_SCHEMA.$EXA_TABLE")
+  }
+
+  test("test dataframe save with different modes") {
+    createDummyTable()
+    val initialCnt =
+      exaManager.withCountQuery(s"SELECT COUNT(*) FROM $EXA_SCHEMA.$EXA_TABLE")
+
+    val results: Map[(String, Int), Long] = Map(
+      ("ignore", 1) -> initialCnt,
+      ("overwrite", 2) -> testData.size.toLong,
+      ("append", 3) -> (initialCnt + testData.size)
+    )
+
+    results.foreach {
+      case ((mode, parts), expected) =>
+        assert(runWithSaveMode(mode, parts) === expected)
+    }
+
+    // Error if table exists
+    val thrown = intercept[RuntimeException] {
+      runWithSaveMode("errorifexists", 4)
+    }
+    val expectedMsg = s"Table $EXA_SCHEMA.$EXA_TABLE already exists. " +
+      "Use one of other SaveMode modes: 'append', 'overwrite' or 'ignore'"
+    assert(thrown.getMessage === expectedMsg)
   }
 
 }

--- a/src/main/scala/com/exasol/spark/DefaultSource.scala
+++ b/src/main/scala/com/exasol/spark/DefaultSource.scala
@@ -1,18 +1,26 @@
 package com.exasol.spark
 
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
 
 import com.exasol.spark.util.ExasolConfiguration
 import com.exasol.spark.util.ExasolConnectionManager
+import com.exasol.spark.writer.ExasolWriter
 
 /**
  * A data source for creating integration between Exasol and Spark
  *
  * It also serves as a factory class to create [[ExasolRelation]] instances for Spark application.
  */
-class DefaultSource extends RelationProvider with DataSourceRegister with SchemaRelationProvider {
+class DefaultSource
+    extends RelationProvider
+    with DataSourceRegister
+    with SchemaRelationProvider
+    with CreatableRelationProvider {
 
   override def shortName(): String = "exasol"
 
@@ -53,6 +61,87 @@ class DefaultSource extends RelationProvider with DataSourceRegister with Schema
     val manager = createManager(parameters, sqlContext)
     new ExasolRelation(sqlContext, queryString, Option(schema), manager)
   }
+
+  /**
+   * Creates an [[ExasolRelation]] after saving a Spark dataframe into Exasol table
+   *
+   * @param sqlContext A Spark [[org.apache.spark.sql.SQLContext]] context
+   * @param mode One of Spark save modes, [[org.apache.spark.sql.SaveMode]]
+   * @param parameters The parameters provided as options, `table` parameter is required for write
+   * @param data A Spark [[org.apache.spark.sql.DataFrame]] to save as a Exasol table
+   * @return An [[ExasolRelation]] relation
+   */
+  override def createRelation(
+    sqlContext: SQLContext,
+    mode: SaveMode,
+    parameters: Map[String, String],
+    data: DataFrame
+  ): BaseRelation = {
+    val tableName = getKValue("table", parameters)
+    val manager = createManager(parameters, sqlContext)
+
+    val isTableExist = manager.tableExists(tableName)
+
+    mode match {
+      case SaveMode.Overwrite =>
+        if (!isTableExist) {
+          // maybe createTable?
+          throw new RuntimeException(
+            s"Table $tableName does not exist when saving with 'overwrite' mode"
+          )
+        }
+        manager.truncateTable(tableName)
+        saveDFTable(sqlContext, data, tableName, manager)
+
+      case SaveMode.Append =>
+        if (!isTableExist) {
+          // maybe createTable?
+          throw new RuntimeException(
+            s"Table $tableName does not exist when saving with 'append' mode"
+          )
+        }
+        saveDFTable(sqlContext, data, tableName, manager)
+
+      case SaveMode.ErrorIfExists =>
+        if (isTableExist) {
+          throw new RuntimeException(
+            s"Table $tableName already exists." +
+              " Use one of other SaveMode modes: 'append', 'overwrite' or 'ignore'"
+          )
+        }
+      // createTable
+      // saveDFTable
+
+      case SaveMode.Ignore =>
+        if (!isTableExist) {
+          // createTable
+          // saveDFTable
+        }
+    }
+
+    val newParams = parameters ++ Map("query" -> s"SELECT * FROM $tableName")
+    createRelation(sqlContext, newParams, data.schema)
+  }
+
+  def saveDFTable(
+    sqlContext: SQLContext,
+    df: DataFrame,
+    tableName: String,
+    manager: ExasolConnectionManager
+  ): Unit = {
+    val writer = new ExasolWriter(sqlContext.sparkContext, tableName, df.schema, manager)
+    val exaNodes = writer.startParallel()
+    val newDF = repartitionPerNode(df, exaNodes)
+
+    newDF.rdd.foreachPartition(iter => writer.insertPartition(iter))
+  }
+
+  def repartitionPerNode(df: DataFrame, nodesCnt: Int): DataFrame =
+    if (nodesCnt < df.rdd.getNumPartitions) {
+      df.coalesce(nodesCnt)
+    } else {
+      df
+    }
 
   private[this] def getKValue(key: String, parameters: Map[String, String]): String =
     parameters.get(key) match {

--- a/src/main/scala/com/exasol/spark/DefaultSource.scala
+++ b/src/main/scala/com/exasol/spark/DefaultSource.scala
@@ -1,35 +1,53 @@
 package com.exasol.spark
 
 import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.sources.{
-  BaseRelation,
-  DataSourceRegister,
-  RelationProvider,
-  SchemaRelationProvider
-}
+import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
 
-import com.exasol.spark.util.{ExasolConfiguration, ExasolConnectionManager}
+import com.exasol.spark.util.ExasolConfiguration
+import com.exasol.spark.util.ExasolConnectionManager
 
+/**
+ * A data source for creating integration between Exasol and Spark
+ *
+ * It also serves as a factory class to create [[ExasolRelation]] instances for Spark application.
+ */
 class DefaultSource extends RelationProvider with DataSourceRegister with SchemaRelationProvider {
 
   override def shortName(): String = "exasol"
 
+  /**
+   * Creates an [[ExasolRelation]] using provided Spark [[org.apache.spark.sql.SQLContext]] and
+   * parameters
+   *
+   * The schema is inferred by running the Exasol query with `LIMIT 1` clause.
+   *
+   * @param sqlContext A Spark [[org.apache.spark.sql.SQLContext]] context
+   * @param parameters The parameters provided as options
+   * @return A [[ExasolRelation]]
+   */
   override def createRelation(
     sqlContext: SQLContext,
     parameters: Map[String, String]
   ): BaseRelation = {
-
     val (queryString, manager) = fromParameters(parameters, sqlContext)
     new ExasolRelation(sqlContext, queryString, None, manager)
   }
 
+  /**
+   * Creates an [[ExasolRelation]] using the provided Spark [[org.apache.spark.sql.SQLContext]],
+   * parameters and schema
+   *
+   * @param sqlContext A Spark [[org.apache.spark.sql.SQLContext]] context
+   * @param parameters The parameters provided as options
+   * @param schema A user provided schema used to select columns for the relation
+   * @return A [[ExasolRelation]]
+   */
   override def createRelation(
     sqlContext: SQLContext,
     parameters: Map[String, String],
     schema: StructType
   ): BaseRelation = {
-
     val (queryString, manager) = fromParameters(parameters, sqlContext)
     new ExasolRelation(sqlContext, queryString, Option(schema), manager)
   }
@@ -42,7 +60,7 @@ class DefaultSource extends RelationProvider with DataSourceRegister with Schema
       .filter { case (key, _) => key.startsWith(s"spark.exasol.") }
       .map { case (key, value) => key.substring(s"spark.exasol.".length) -> value }
 
-  private def fromParameters(
+  private[this] def fromParameters(
     parameters: Map[String, String],
     sqlContext: SQLContext
   ): (String, ExasolConnectionManager) = {
@@ -57,4 +75,5 @@ class DefaultSource extends RelationProvider with DataSourceRegister with Schema
     val manager = ExasolConnectionManager(config)
     (queryString, manager)
   }
+
 }

--- a/src/main/scala/com/exasol/spark/ExasolRelation.scala
+++ b/src/main/scala/com/exasol/spark/ExasolRelation.scala
@@ -86,7 +86,7 @@ class ExasolRelation(
   private[this] def makeEmptyRDD(filters: Array[Filter]): RDD[Row] = {
     val cntQuery = enrichQuery(Array.empty[String], filters)
     val cnt = manager.withCountQuery(cntQuery)
-    sqlContext.sparkContext.parallelize(1L to cnt, 4).map(r => Row.empty)
+    sqlContext.sparkContext.parallelize(1L to cnt, 4).map(_ => Row.empty)
   }
 
   /**

--- a/src/main/scala/com/exasol/spark/ExasolWriter.scala
+++ b/src/main/scala/com/exasol/spark/ExasolWriter.scala
@@ -12,6 +12,7 @@ import org.apache.spark.sql.types.StructType
 import com.exasol.jdbc.EXAConnection
 import com.exasol.spark.util.Converter
 import com.exasol.spark.util.ExasolConnectionManager
+import com.exasol.spark.util.Types
 
 import com.typesafe.scalalogging.LazyLogging
 
@@ -74,7 +75,7 @@ class ExasolWriter(
     val stmt = subConn.prepareStatement(insertStmt)
 
     val setters = rddSchema.fields.map(f => Converter.makeSetter(f.dataType))
-    val nullTypes = rddSchema.fields.map(f => Converter.jdbcTypeFromDataType(f.dataType))
+    val nullTypes = rddSchema.fields.map(f => Types.jdbcTypeFromSparkDataType(f.dataType))
     val fieldCnt = rddSchema.fields.length
 
     // TODO: This should be from manager configs. Similarly add another parameter (used in write)

--- a/src/main/scala/com/exasol/spark/ExasolWriter.scala
+++ b/src/main/scala/com/exasol/spark/ExasolWriter.scala
@@ -1,0 +1,127 @@
+package com.exasol.spark.writer
+
+import java.sql.SQLException
+
+import org.apache.spark.SparkContext
+import org.apache.spark.TaskContext
+import org.apache.spark.scheduler.SparkListener
+import org.apache.spark.scheduler.SparkListenerApplicationEnd
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.StructType
+
+import com.exasol.jdbc.EXAConnection
+import com.exasol.spark.util.Converter
+import com.exasol.spark.util.ExasolConnectionManager
+
+import com.typesafe.scalalogging.LazyLogging
+
+/**
+ *
+ */
+class ExasolWriter(
+  @transient val sc: SparkContext,
+  tableName: String,
+  rddSchema: StructType,
+  manager: ExasolConnectionManager
+) extends Serializable
+    with LazyLogging {
+
+  // scalastyle:off null
+  @transient private var mainConnection: EXAConnection = null
+  private var hosts: Seq[String] = null
+  // scalastyle:on
+
+  def closeMainResources(): Unit =
+    if (mainConnection != null && !mainConnection.isClosed) {
+      mainConnection.close()
+    }
+
+  def startParallel(): Int = {
+    mainConnection = manager.writerMainConnection()
+
+    if (mainConnection == null) {
+      logger.error("Could not create main connection!")
+      throw new RuntimeException("Could not create main connection to Exasol!")
+    }
+
+    val cnt = manager.initParallel(mainConnection)
+    logger.info(s"Initiated $cnt parallel sub connections")
+
+    // Close Exasol main connection when SparkContext finishes. This is a lifetime of a Spark
+    // application.
+    sc.addSparkListener(new SparkListener {
+      override def onApplicationEnd(appEnd: SparkListenerApplicationEnd): Unit =
+        closeMainResources()
+    })
+
+    // Populate hosts
+    hosts = manager.subConnections(mainConnection)
+
+    cnt
+  }
+
+  def insertStmt(): String = {
+    val columns = rddSchema.fields.map(_.name).mkString(",")
+    val placeholders = rddSchema.fields.map(_ => "?").mkString(",")
+    s"INSERT INTO $tableName ($columns) VALUES ($placeholders)"
+  }
+
+  def insertPartition(iter: Iterator[Row]): Unit = {
+    val partitionId = TaskContext.getPartitionId()
+    val subConnectionUrl = hosts(partitionId)
+    val subConn = manager.subConnection(subConnectionUrl)
+
+    val stmt = subConn.prepareStatement(insertStmt)
+
+    val setters = rddSchema.fields.map(f => Converter.makeSetter(f.dataType))
+    val nullTypes = rddSchema.fields.map(f => Converter.jdbcTypeFromDataType(f.dataType))
+    val fieldCnt = rddSchema.fields.length
+
+    // TODO: This should be from manager configs. Similarly add another parameter (used in write)
+    // for per node package count.
+    val batchSize = 100
+
+    try {
+      var rowCnt = 0
+      var totalCnt = 0
+
+      while (iter.hasNext) {
+        val row = iter.next()
+        var i = 0
+        while (i < fieldCnt) {
+          if (row.isNullAt(i)) {
+            stmt.setNull(i + 1, nullTypes(i))
+          } else {
+            setters(i).apply(stmt, row, i)
+          }
+          i = i + 1
+        }
+        stmt.addBatch()
+        rowCnt += 1
+        if (rowCnt % batchSize == 0) {
+          val _ = stmt.executeBatch()
+          totalCnt += rowCnt
+          rowCnt = 0
+        }
+      }
+      if (rowCnt > 0) {
+        val _ = stmt.executeBatch()
+        totalCnt += rowCnt
+      }
+      logger.info(s"Inserted in total $totalCnt rows into table $tableName")
+
+      ()
+    } catch {
+      case ex: SQLException =>
+        logger.error(s"Error during statement batch execution ${ex.printStackTrace()}")
+        throw ex
+    } finally {
+      logger.info("Closing sub connection statement and connection")
+      stmt.close()
+      subConn.commit()
+      subConn.close()
+    }
+
+  }
+
+}

--- a/src/main/scala/com/exasol/spark/ExasolWriter.scala
+++ b/src/main/scala/com/exasol/spark/ExasolWriter.scala
@@ -78,9 +78,7 @@ class ExasolWriter(
     val nullTypes = rddSchema.fields.map(f => Types.jdbcTypeFromSparkDataType(f.dataType))
     val fieldCnt = rddSchema.fields.length
 
-    // TODO: This should be from manager configs. Similarly add another parameter (used in write)
-    // for per node package count.
-    val batchSize = 100
+    val batchSize = manager.config.batch_size
 
     try {
       var rowCnt = 0

--- a/src/main/scala/com/exasol/spark/rdd/ExasolRDD.scala
+++ b/src/main/scala/com/exasol/spark/rdd/ExasolRDD.scala
@@ -3,7 +3,6 @@ package com.exasol.spark.rdd
 import java.sql.ResultSet
 import java.sql.Statement
 
-import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
 import org.apache.spark.Partition
@@ -97,7 +96,7 @@ class ExasolRDD(
   override def compute(split: Partition, context: TaskContext): Iterator[Row] = {
     var closed = false
     var resultSet: ResultSet = null
-    var stmt: Statement = null
+    val stmt: Statement = null
     var conn: EXAConnection = null
 
     def close(): Unit = {

--- a/src/main/scala/com/exasol/spark/rdd/ExasolRDDPartition.scala
+++ b/src/main/scala/com/exasol/spark/rdd/ExasolRDDPartition.scala
@@ -9,6 +9,7 @@ import org.apache.spark.Partition
  * materializes the data of a node based on the information represented by a partition.
  *
  * @param idx A partition identifier (0 based)
+ * @param handle A Exasol sub connection query identifier handle
  * @param connectionUrl An exasol jdbc (sub) connection string
  *
  */

--- a/src/main/scala/com/exasol/spark/util/Converter.scala
+++ b/src/main/scala/com/exasol/spark/util/Converter.scala
@@ -213,36 +213,13 @@ object Converter extends LazyLogging {
       (stmt: PreparedStatement, row: Row, pos: Int) =>
         stmt.setDate(pos + 1, row.getAs[java.sql.Date](pos))
 
-    case t: DecimalType =>
+    case dt: DecimalType =>
       (stmt: PreparedStatement, row: Row, pos: Int) =>
         stmt.setBigDecimal(pos + 1, row.getDecimal(pos))
 
     case _ =>
       (_: PreparedStatement, _: Row, pos: Int) =>
-        throw new IllegalArgumentException(s"Can't translate non-null value for field $pos")
-  }
-
-  /**
-   * Return corresponding Jdbc [[java.sql.Types]] type given Spark
-   * [[org.apache.spark.sql.types.DataType]] type
-   *
-   * @param dataType A Spark DataType (e.g. [[org.apache.spark.sql.types.StringType]])
-   * @return A default JdbcType for this DataType
-   */
-  private[spark] def jdbcTypeFromDataType(dataType: DataType): Int = dataType match {
-    case IntegerType    => java.sql.Types.INTEGER
-    case LongType       => java.sql.Types.BIGINT
-    case DoubleType     => java.sql.Types.DOUBLE
-    case FloatType      => java.sql.Types.FLOAT
-    case ShortType      => java.sql.Types.SMALLINT
-    case ByteType       => java.sql.Types.TINYINT
-    case BooleanType    => java.sql.Types.BIT
-    case StringType     => java.sql.Types.CLOB
-    case BinaryType     => java.sql.Types.BLOB
-    case TimestampType  => java.sql.Types.TIMESTAMP
-    case DateType       => java.sql.Types.DATE
-    case t: DecimalType => java.sql.Types.DECIMAL
-    case _              => throw new RuntimeException("Unsupported jdbc type!")
+        throw new IllegalArgumentException(s"Cannot translate non-null value for field $pos")
   }
 
 }

--- a/src/main/scala/com/exasol/spark/util/Converter.scala
+++ b/src/main/scala/com/exasol/spark/util/Converter.scala
@@ -1,5 +1,6 @@
 package com.exasol.spark.util
 
+import java.sql.PreparedStatement
 import java.sql.ResultSet
 
 import org.apache.spark.sql.Row
@@ -61,9 +62,9 @@ object Converter extends LazyLogging {
       }
   }
 
-  // A `JDBCValueGetter` is responsible for getting a value from `ResultSet` into a field
-  // for `MutableRow`. The last argument `Int` means the index for the value to be set in
-  // the row and also used for the value in `ResultSet`.
+  // A `JDBCValueGetter` is responsible for getting a value from `ResultSet` into a field for
+  // `MutableRow`. The last argument `Int` means the index for the value to be set in the row and
+  // also used for the value in `ResultSet`.
   private type JDBCValueGetter = (ResultSet, InternalRow, Int) => Unit
 
   /**
@@ -161,5 +162,87 @@ object Converter extends LazyLogging {
       f(input)
     }
   // scalastyle:on null
+
+  // A `JDBCValueSetter` is responsible for setting a value from `Row` into a field for
+  // `PreparedStatement`. The last argument `Int` means the index for the value to be set in the
+  // SQL statement and also used for the value in `Row`.
+  private type JDBCValueSetter = (PreparedStatement, Row, Int) => Unit
+
+  private[spark] def makeSetter(dataType: DataType): JDBCValueSetter = dataType match {
+    case IntegerType =>
+      (stmt: PreparedStatement, row: Row, pos: Int) =>
+        stmt.setInt(pos + 1, row.getInt(pos))
+
+    case LongType =>
+      (stmt: PreparedStatement, row: Row, pos: Int) =>
+        stmt.setLong(pos + 1, row.getLong(pos))
+
+    case DoubleType =>
+      (stmt: PreparedStatement, row: Row, pos: Int) =>
+        stmt.setDouble(pos + 1, row.getDouble(pos))
+
+    case FloatType =>
+      (stmt: PreparedStatement, row: Row, pos: Int) =>
+        stmt.setFloat(pos + 1, row.getFloat(pos))
+
+    case ShortType =>
+      (stmt: PreparedStatement, row: Row, pos: Int) =>
+        stmt.setShort(pos + 1, row.getShort(pos))
+
+    case ByteType =>
+      (stmt: PreparedStatement, row: Row, pos: Int) =>
+        stmt.setByte(pos + 1, row.getByte(pos))
+
+    case BooleanType =>
+      (stmt: PreparedStatement, row: Row, pos: Int) =>
+        stmt.setBoolean(pos + 1, row.getBoolean(pos))
+
+    case StringType =>
+      (stmt: PreparedStatement, row: Row, pos: Int) =>
+        stmt.setString(pos + 1, row.getString(pos))
+
+    case BinaryType =>
+      (stmt: PreparedStatement, row: Row, pos: Int) =>
+        stmt.setBytes(pos + 1, row.getAs[Array[Byte]](pos))
+
+    case TimestampType =>
+      (stmt: PreparedStatement, row: Row, pos: Int) =>
+        stmt.setTimestamp(pos + 1, row.getAs[java.sql.Timestamp](pos))
+
+    case DateType =>
+      (stmt: PreparedStatement, row: Row, pos: Int) =>
+        stmt.setDate(pos + 1, row.getAs[java.sql.Date](pos))
+
+    case t: DecimalType =>
+      (stmt: PreparedStatement, row: Row, pos: Int) =>
+        stmt.setBigDecimal(pos + 1, row.getDecimal(pos))
+
+    case _ =>
+      (_: PreparedStatement, _: Row, pos: Int) =>
+        throw new IllegalArgumentException(s"Can't translate non-null value for field $pos")
+  }
+
+  /**
+   * Return corresponding Jdbc [[java.sql.Types]] type given Spark
+   * [[org.apache.spark.sql.types.DataType]] type
+   *
+   * @param dataType A Spark DataType (e.g. [[org.apache.spark.sql.types.StringType]])
+   * @return A default JdbcType for this DataType
+   */
+  private[spark] def jdbcTypeFromDataType(dataType: DataType): Int = dataType match {
+    case IntegerType    => java.sql.Types.INTEGER
+    case LongType       => java.sql.Types.BIGINT
+    case DoubleType     => java.sql.Types.DOUBLE
+    case FloatType      => java.sql.Types.FLOAT
+    case ShortType      => java.sql.Types.SMALLINT
+    case ByteType       => java.sql.Types.TINYINT
+    case BooleanType    => java.sql.Types.BIT
+    case StringType     => java.sql.Types.CLOB
+    case BinaryType     => java.sql.Types.BLOB
+    case TimestampType  => java.sql.Types.TIMESTAMP
+    case DateType       => java.sql.Types.DATE
+    case t: DecimalType => java.sql.Types.DECIMAL
+    case _              => throw new RuntimeException("Unsupported jdbc type!")
+  }
 
 }

--- a/src/main/scala/com/exasol/spark/util/ExasolConfiguration.scala
+++ b/src/main/scala/com/exasol/spark/util/ExasolConfiguration.scala
@@ -44,7 +44,9 @@ final case class ExasolConfiguration(
   port: Int,
   username: String,
   password: String,
-  max_nodes: Int
+  max_nodes: Int,
+  create_table: Boolean,
+  batch_size: Int
 )
 
 object ExasolConfiguration {
@@ -60,7 +62,9 @@ object ExasolConfiguration {
       port = opts.getOrElse("port", "8888").toInt,
       username = opts.getOrElse("username", "sys"),
       password = opts.getOrElse("password", "exasol"),
-      max_nodes = opts.getOrElse("max_nodes", "200").toInt
+      max_nodes = opts.getOrElse("max_nodes", "200").toInt,
+      create_table = opts.getOrElse("create_table", "false").toBoolean,
+      batch_size = opts.getOrElse("batch_size", "1000").toInt
     )
 
 }

--- a/src/main/scala/com/exasol/spark/util/ExasolConnectionManager.scala
+++ b/src/main/scala/com/exasol/spark/util/ExasolConnectionManager.scala
@@ -1,6 +1,5 @@
 package com.exasol.spark.util
 
-import java.sql.Connection
 import java.sql.DriverManager
 import java.util.concurrent.ConcurrentHashMap
 

--- a/src/main/scala/com/exasol/spark/util/ExasolConnectionManager.scala
+++ b/src/main/scala/com/exasol/spark/util/ExasolConnectionManager.scala
@@ -166,6 +166,23 @@ final case class ExasolConnectionManager(config: ExasolConfiguration) {
     ()
   }
 
+  /** Given an Exasol table name (with schema, e.g mySchema.myTable format), drop it */
+  def dropTable(tableName: String): Unit = withStatement[Unit] { stmt =>
+    val _ = stmt.executeUpdate(s"DROP TABLE IF EXISTS $tableName")
+    ()
+  }
+
+  /**
+   * Creates a table in Exasol
+   *
+   * @param tableName A table name (with both schema and table, e.g. myschem.my_table)
+   * @param tabelSchema A schema string of table with column names and types
+   */
+  def createTable(tableName: String, tableSchema: String): Unit = withStatement[Unit] { stmt =>
+    val _ = stmt.executeUpdate(s"CREATE TABLE $tableName ($tableSchema)")
+    ()
+  }
+
 }
 
 /**

--- a/src/main/scala/com/exasol/spark/util/ExasolConnectionManager.scala
+++ b/src/main/scala/com/exasol/spark/util/ExasolConnectionManager.scala
@@ -32,6 +32,13 @@ final case class ExasolConnectionManager(config: ExasolConfiguration) {
       config.password
     )
 
+  def writerMainConnection(): EXAConnection =
+    ExasolConnectionManager.makeConnection(
+      s"$getJdbcConnectionString;autocommit=0",
+      config.username,
+      config.password
+    )
+
   /**
    * A single non-pooled [[com.exasol.jdbc.EXAConnection]] connection
    *

--- a/src/main/scala/com/exasol/spark/util/ExasolConnectionManager.scala
+++ b/src/main/scala/com/exasol/spark/util/ExasolConnectionManager.scala
@@ -5,16 +5,43 @@ import java.sql.DriverManager
 import java.util.concurrent.ConcurrentHashMap
 
 import com.exasol.jdbc.EXAConnection
+import com.exasol.jdbc.EXAResultSet
+import com.exasol.jdbc.EXAStatement
 
 import com.typesafe.scalalogging.LazyLogging
 
+/**
+ * A class that provides and manages Exasol connections
+ *
+ * It is okay to serialize this class to Spark workers, it will create Exasol jdbc connections
+ * within each executor JVM.
+ *
+ * @param config An [[ExasolConfiguration]] with user provided or runtime configuration parameters
+ *
+ */
 final case class ExasolConnectionManager(config: ExasolConfiguration) {
 
-  def mainConnectionUrl(): String =
-    s"jdbc:exa:${config.host}:${config.port}"
+  /** A regular Exasol jdbc connection string */
+  def getJdbcConnectionString(): String = s"jdbc:exa:${config.host}:${config.port}"
 
   def mainConnection(): EXAConnection =
-    ExasolConnectionManager.makeConnection(mainConnectionUrl, config.username, config.password)
+    ExasolConnectionManager.makeConnection(
+      getJdbcConnectionString,
+      config.username,
+      config.password
+    )
+
+  /**
+   * A single non-pooled [[com.exasol.jdbc.EXAConnection]] connection
+   *
+   * Maintaining and gracefully closing the connection is a responsibility of the user.
+   */
+  def getConnection(): EXAConnection =
+    ExasolConnectionManager.createConnection(
+      getJdbcConnectionString,
+      config.username,
+      config.password
+    )
 
   def initParallel(mainConn: EXAConnection): Int =
     mainConn.EnterParallel(config.max_nodes)
@@ -34,25 +61,80 @@ final case class ExasolConnectionManager(config: ExasolConfiguration) {
   def subConnection(subConnectionUrl: String): EXAConnection =
     ExasolConnectionManager.makeConnection(subConnectionUrl, config.username, config.password)
 
+  /**
+   * A method to run with a new connection
+   *
+   * This method closes the connection afterwards.
+   *
+   * @param handle A code block that needs to be run with a connection
+   * @tparam T A result type of the `handle` function
+   * @return A result of `handle` function
+   *
+   */
   def withConnection[T](handle: EXAConnection => T): T =
-    ExasolConnectionManager
-      .withConnection(mainConnectionUrl, config.username, config.password)(handle)
+    ExasolConnectionManager.using(getConnection)(handle)
 
-  def withCountQuery(query: String): Long = withConnection[Long] { conn =>
-    val stmt = conn.createStatement()
-    val resultSet = stmt.executeQuery(query)
-    val cnt = if (resultSet.next()) {
-      resultSet.getLong(1)
+  /**
+   * A helper method to run with a new statement
+   *
+   * This method closes the resources afterwards.
+   *
+   * @param handle A code block that needs to be run with a given statement
+   * @tparam T A result type of the `handle` function
+   * @return A result of `handle` function
+   *
+   */
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  def withStatement[T](handle: EXAStatement => T): T = withConnection[T] { conn =>
+    val stmt = conn.createStatement().asInstanceOf[EXAStatement]
+    ExasolConnectionManager.using(stmt)(handle)
+  }
+
+  /**
+   * A helper method to run `stmt.execute` given a list of queries
+   *
+   * @param queries A list of SQL queries to run
+   * @return A [[scala.Unit]] result
+   *
+   */
+  def withExecute(queries: Seq[String]): Unit = withStatement[Unit] { stmt =>
+    queries.foreach { query =>
+      stmt.execute(query)
+    }
+    ()
+  }
+
+  /**
+   * A helper method to run `stmt.executeQuery` given a query
+   *
+   * @param query A query string to executeQuery
+   * @tparam T A result type of the `handle` function
+   * @return A result of `handle` function
+   *
+   */
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  def withExecuteQuery[T](query: String)(handle: EXAResultSet => T): T = withStatement[T] {
+    stmt =>
+      val rs = stmt.executeQuery(query).asInstanceOf[EXAResultSet]
+      ExasolConnectionManager.using(rs)(handle)
+  }
+
+  /** Given a query with `count(*)` returns the result */
+  def withCountQuery(query: String): Long = withExecuteQuery[Long](query) { rs =>
+    val cnt = if (rs.next()) {
+      rs.getLong(1)
     } else {
       throw new IllegalStateException("Could not query the count!")
     }
-    resultSet.close()
-    stmt.close()
     cnt
   }
 
 }
 
+/**
+ * The companion object to [[ExasolConnectionManager]]
+ *
+ */
 object ExasolConnectionManager extends LazyLogging {
 
   private[this] val JDBC_LOGIN_TIMEOUT: Int = 30
@@ -61,7 +143,7 @@ object ExasolConnectionManager extends LazyLogging {
     new ConcurrentHashMap()
 
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-  private[this] def createConnection(
+  private[util] def createConnection(
     url: String,
     username: String,
     password: String
@@ -88,11 +170,6 @@ object ExasolConnectionManager extends LazyLogging {
     }
     connections.get(url)
   }
-
-  def withConnection[T](url: String, username: String, password: String)(
-    handle: EXAConnection => T
-  ): T =
-    using(createConnection(url, username, password))(handle)
 
   def using[A <: AutoCloseable, T](resource: A)(fn: A => T): T =
     try {

--- a/src/test/scala/com/exasol/spark/DefaultSourceSuite.scala
+++ b/src/test/scala/com/exasol/spark/DefaultSourceSuite.scala
@@ -50,13 +50,21 @@ class DefaultSourceSuite extends FunSuite with Matchers with MockitoSugar {
     assert(source.repartitionPerNode(df, 2) === df)
     assert(source.repartitionPerNode(df, 2).rdd.getNumPartitions === 2)
 
-    val reducedDF = mock[DataFrame]
-    val reducedRdd = mock[RDD[Row]]
-    when(reducedDF.rdd).thenReturn(reducedRdd)
-    when(reducedRdd.getNumPartitions).thenReturn(1)
+    val repartedDF = mock[DataFrame]
+    val repartedRdd = mock[RDD[Row]]
+    when(repartedDF.rdd).thenReturn(repartedRdd)
+    when(repartedRdd.getNumPartitions).thenReturn(3)
 
-    when(df.coalesce(1)).thenReturn(reducedDF)
-    assert(source.repartitionPerNode(df, 1) === reducedDF)
+    when(df.repartition(3)).thenReturn(repartedDF)
+    assert(source.repartitionPerNode(df, 3).rdd.getNumPartitions === 3)
+
+    val coalescedDF = mock[DataFrame]
+    val coalescedRdd = mock[RDD[Row]]
+    when(coalescedDF.rdd).thenReturn(coalescedRdd)
+    when(coalescedRdd.getNumPartitions).thenReturn(1)
+
+    when(df.coalesce(1)).thenReturn(coalescedDF)
+    assert(source.repartitionPerNode(df, 1) === coalescedDF)
     assert(source.repartitionPerNode(df, 1).rdd.getNumPartitions === 1)
   }
 

--- a/src/test/scala/com/exasol/spark/DefaultSourceSuite.scala
+++ b/src/test/scala/com/exasol/spark/DefaultSourceSuite.scala
@@ -1,7 +1,13 @@
 package com.exasol.spark
 
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.SQLContext
 
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
+import org.mockito.Mockito.when
 import org.scalatest.{FunSuite, Matchers}
 import org.scalatest.mockito.MockitoSugar
 
@@ -17,6 +23,41 @@ class DefaultSourceSuite extends FunSuite with Matchers with MockitoSugar {
     assert(
       thrown.getMessage === "A query parameter should be specified in order to run the operation"
     )
+  }
+
+  test("when saving should throw an Exception if no `table` parameter is provided") {
+    val df = mock[DataFrame]
+    val sqlContext = mock[SQLContext]
+
+    val thrown = intercept[UnsupportedOperationException] {
+      new DefaultSource().createRelation(sqlContext, SaveMode.Append, Map[String, String](), df)
+    }
+
+    assert(
+      thrown.getMessage === "A table parameter should be specified in order to run the operation"
+    )
+  }
+
+  test("`repartitionPerNode` should reduce dataframe partitions number") {
+    val df = mock[DataFrame]
+    val rdd = mock[RDD[Row]]
+
+    when(df.rdd).thenReturn(rdd)
+    when(rdd.getNumPartitions).thenReturn(2)
+
+    val source = new DefaultSource()
+
+    assert(source.repartitionPerNode(df, 2) === df)
+    assert(source.repartitionPerNode(df, 2).rdd.getNumPartitions === 2)
+
+    val reducedDF = mock[DataFrame]
+    val reducedRdd = mock[RDD[Row]]
+    when(reducedDF.rdd).thenReturn(reducedRdd)
+    when(reducedRdd.getNumPartitions).thenReturn(1)
+
+    when(df.coalesce(1)).thenReturn(reducedDF)
+    assert(source.repartitionPerNode(df, 1) === reducedDF)
+    assert(source.repartitionPerNode(df, 1).rdd.getNumPartitions === 1)
   }
 
   test("mergeConfigurations should merge runtime sparkConf into user provided parameters") {

--- a/src/test/scala/com/exasol/spark/DefaultSourceSuite.scala
+++ b/src/test/scala/com/exasol/spark/DefaultSourceSuite.scala
@@ -5,6 +5,7 @@ import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.types._
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
 import org.mockito.Mockito.when
@@ -68,7 +69,7 @@ class DefaultSourceSuite extends FunSuite with Matchers with MockitoSugar {
     assert(source.repartitionPerNode(df, 1).rdd.getNumPartitions === 1)
   }
 
-  test("mergeConfigurations should merge runtime sparkConf into user provided parameters") {
+  test("`mergeConfigurations` should merge runtime sparkConf into user provided parameters") {
     val sparkConf = Map[String, String](
       "spark.exasol.username" -> "newUsername",
       "spark.exasol.host" -> "hostName",

--- a/src/test/scala/com/exasol/spark/DefaultSourceSuite.scala
+++ b/src/test/scala/com/exasol/spark/DefaultSourceSuite.scala
@@ -6,7 +6,8 @@ import org.scalatest.{FunSuite, Matchers}
 import org.scalatest.mockito.MockitoSugar
 
 class DefaultSourceSuite extends FunSuite with Matchers with MockitoSugar {
-  test("fromParameters should throw Exception when no query is provided") {
+
+  test("when reading should throw an Exception if no `query` parameter is provided") {
     val sqlContext = mock[SQLContext]
 
     val thrown = intercept[UnsupportedOperationException] {
@@ -14,11 +15,11 @@ class DefaultSourceSuite extends FunSuite with Matchers with MockitoSugar {
     }
 
     assert(
-      thrown.getMessage === "A sql query string should be specified when loading from Exasol"
+      thrown.getMessage === "A query parameter should be specified in order to run the operation"
     )
   }
 
-  test("mergeConfiguration should merge runtime exasol sparkConf into user provided parameters") {
+  test("mergeConfigurations should merge runtime sparkConf into user provided parameters") {
     val sparkConf = Map[String, String](
       "spark.exasol.username" -> "newUsername",
       "spark.exasol.host" -> "hostName",
@@ -26,7 +27,7 @@ class DefaultSourceSuite extends FunSuite with Matchers with MockitoSugar {
     )
     val parameters = Map[String, String]("username" -> "oldUsername", "password" -> "oldPassword")
 
-    val newConf = new DefaultSource().mergeConfiguration(parameters, sparkConf)
+    val newConf = new DefaultSource().mergeConfigurations(parameters, sparkConf)
     // overwrite config if both are provided
     assert(newConf.getOrElse("username", "not available") === "newUsername")
 

--- a/src/test/scala/com/exasol/spark/ExasolRelationSuite.scala
+++ b/src/test/scala/com/exasol/spark/ExasolRelationSuite.scala
@@ -2,7 +2,6 @@ package com.exasol.spark
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
 

--- a/src/test/scala/com/exasol/spark/util/FiltersSuite.scala
+++ b/src/test/scala/com/exasol/spark/util/FiltersSuite.scala
@@ -83,7 +83,7 @@ class FiltersSuite extends FunSuite with Matchers {
     assert(createWhereClause(testSchema, filters) === expected)
   }
 
-  // scalastyle:off
+  // scalastyle:off nonascii
   test("creates where clause from EqualTo with different data types") {
     val filters = Seq(
       EqualTo("bool_col", false),
@@ -112,7 +112,7 @@ class FiltersSuite extends FunSuite with Matchers {
 
     assert(createWhereClause(testSchema, filters) === expected)
   }
-  // scalastyle:on
+  // scalastyle:on nonascii
 
   test("creates where clause from a nested list of filters") {
     val filters = Seq(

--- a/src/test/scala/com/exasol/spark/util/TypesSuite.scala
+++ b/src/test/scala/com/exasol/spark/util/TypesSuite.scala
@@ -150,4 +150,24 @@ class TypesSuite extends FunSuite with Matchers {
     )
   }
 
+  test("`createTableSchema` should create a comma separated column names and types") {
+    val schema: StructType = StructType(
+      Seq(
+        StructField("bool_col", BooleanType),
+        StructField("str_col", StringType),
+        StructField("int_col", IntegerType, false),
+        StructField("float_col", FloatType),
+        StructField("double_col", DoubleType),
+        StructField("date_col", DateType),
+        StructField("timestamp_col", TimestampType)
+      )
+    )
+
+    val expectedStr =
+      "bool_col BOOLEAN, str_col CLOB, int_col INTEGER NOT NULL, float_col FLOAT," +
+        " double_col DOUBLE, date_col DATE, timestamp_col TIMESTAMP"
+
+    assert(createTableSchema(schema) === expectedStr)
+  }
+
 }


### PR DESCRIPTION
### What changes are proposed in this PR?

Add a new feature that enable connector users to save the Spark DataFrame into Exasol table. 

In order to save a dataframe, the option `table` should be provided that identify Exasol table. Please note that it should also include the Exasol schema in the table name, e.g. `my_schema.my_table`.

For example:

```scala
df.write
  .mode("overwrite")
  .option("host", "10.0.0.11")
  .option("port", "8563")
  .option("username", "sys")
  .option("password", "exaTheBest")
  .option("table", "my_schema.my_table")
  .format("exasol")
  .save()
```

It is important to know what each Spark SaveMode means here. The Spark write comes with several `SaveMode`-s, please check their descriptions:

```java
/**
 * SaveMode is used to specify the expected behavior of saving a DataFrame to a
 * data source.
 *
 * @since 1.3.0
 */
@InterfaceStability.Stable
public enum SaveMode {
  /** 
   * Append mode means that when saving a DataFrame to a data source, if
   * data/table already exists, contents of the DataFrame are expected to be
   * appended to existing data.
   *
   * @since 1.3.0
   */
  Append,
  /** 
   * Overwrite mode means that when saving a DataFrame to a data source, if
   * data/table already exists, existing data is expected to be overwritten by
   * the contents of the DataFrame.
   *
   * @since 1.3.0
   */
  Overwrite,
  /** 
   * ErrorIfExists mode means that when saving a DataFrame to a data source, if
   * data already exists, an exception is expected to be thrown.
   *
   * @since 1.3.0
   */
  ErrorIfExists,
  /** 
   * Ignore mode means that when saving a DataFrame to a data source, if data
   * already exists, the save operation is expected to not save the contents of
   * the DataFrame and to not change the existing data.
   *
   * @since 1.3.0
   */
  Ignore
}
```

So if the mode is `overwrite` then the table will be truncated and then dataframe will be saved into that table.

Additionally, I introduced a new user provided parameter called `create_table` that is by default set to **false**. This enables connector to create a table if it does not exists.

For instance:

```scala
df.write
  .option("host", "10.0.0.11")
  .option("port", "8563")
  .option("username", "sys")
  .option("password", "exaTheBest")
  .option("create_table", "true")
  .option("table", "my_schema.non_existing_table)
  .format("exasol")
  .save()
```