### PR TITLE
Check that the user provided host parameter value is an IP address

### DIFF
--- a/src/test/scala/com/exasol/spark/DefaultSourceSuite.scala
+++ b/src/test/scala/com/exasol/spark/DefaultSourceSuite.scala
@@ -16,14 +16,24 @@ class DefaultSourceSuite extends FunSuite with Matchers with MockitoSugar {
 
   test("when reading should throw an Exception if no `query` parameter is provided") {
     val sqlContext = mock[SQLContext]
-
     val thrown = intercept[UnsupportedOperationException] {
       new DefaultSource().createRelation(sqlContext, Map[String, String]())
     }
+    val thrownMsg = thrown.getMessage
+    assert(thrownMsg === "A query parameter should be specified in order to run the operation")
+  }
 
-    assert(
-      thrown.getMessage === "A query parameter should be specified in order to run the operation"
-    )
+  test("throws an Exception if host parameter is not an ip address") {
+    val parameters = Map("query" -> "SELECT 1", "host" -> "a.b.c.d")
+    val sqlContext = mock[SQLContext]
+    when(sqlContext.getAllConfs).thenReturn(Map.empty[String, String])
+
+    val thrown = intercept[IllegalArgumentException] {
+      new DefaultSource().createRelation(sqlContext, parameters)
+    }
+
+    val thrownMsg = thrown.getMessage
+    assert(thrownMsg === "The host value should be an ip address of the first Exasol data node!")
   }
 
   test("when saving should throw an Exception if no `table` parameter is provided") {

--- a/src/test/scala/com/exasol/spark/util/ExasolConfigurationSuite.scala
+++ b/src/test/scala/com/exasol/spark/util/ExasolConfigurationSuite.scala
@@ -1,0 +1,44 @@
+package com.exasol.spark.util
+
+import org.scalatest.FunSuite
+import org.scalatest.Matchers
+
+class ExasolConfigurationSuite extends FunSuite with Matchers {
+
+  val validIPv4Addresses: Seq[String] = Seq(
+    "1.1.1.1",
+    "255.255.255.255",
+    "192.168.1.1",
+    "10.10.1.1",
+    "10.0.0.11",
+    "132.254.111.10",
+    "26.10.2.10",
+    "127.0.0.1"
+  )
+
+  val inValidIpv4Addresses: Seq[String] = Seq(
+    "10",
+    "10.10",
+    "10.10.10",
+    "a.a.a.a",
+    "www.exasol.com",
+    "10.0.0.a",
+    "10.10.10.256",
+    "222.222.2.999",
+    "999.10.10.20",
+    "2222.22.22.22",
+    "22.2222.22.2"
+  )
+
+  test("check host value is ipv4") {
+    validIPv4Addresses.foreach { host =>
+      assert(ExasolConfiguration.checkHost(host) === host)
+    }
+    inValidIpv4Addresses.foreach { host =>
+      intercept[IllegalArgumentException] {
+        ExasolConfiguration.checkHost(host)
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This should help to fail-fast if users provide a domain name or non-ip value for the host parameter when using the Spark Exasol connector.

Fixes #43.