### PR TITLE
use withStartupTimeoutSeconds method to specify timeout for ExasolContainer

### DIFF
--- a/src/it/java/org/testcontainers/containers/ExasolDockerContainer.java
+++ b/src/it/java/org/testcontainers/containers/ExasolDockerContainer.java
@@ -31,7 +31,7 @@ JdbcDatabaseContainer<SELF> {
     super.configure();
     withNetworkMode("dockernet");
     withPrivilegedMode(true);
-    withStartupTimeout(Duration.of(EXASOL_STARTUP_TIME, SECONDS));
+    withStartupTimeoutSeconds(EXASOL_STARTUP_TIME);
     withCreateContainerCmdModifier(cmd -> cmd.withIpv4Address(EXASOL_HOST));
   }
 


### PR DESCRIPTION
This fix #51 