### PR TITLE
Use Spark internal.Logging instead of LazyLogging

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,8 +6,8 @@ import sbt._
 object Dependencies {
 
   // Versions
-  private val SparkVersion = "2.4.0"
-  private val ExasolJdbcVersion = "6.0.13"
+  private val SparkVersion = "2.4.3"
+  private val ExasolJdbcVersion = "6.1.3"
 
   private val ScalaTestVersion = "3.0.5"
   private val MockitoVersion = "2.23.4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,6 @@ object Dependencies {
   // Versions
   private val SparkVersion = "2.4.0"
   private val ExasolJdbcVersion = "6.0.13"
-  private val TypesafeLoggingVersion = "3.9.0"
 
   private val ScalaTestVersion = "3.0.5"
   private val MockitoVersion = "2.23.4"
@@ -28,7 +27,6 @@ object Dependencies {
   private val CoreDependencies: Seq[ModuleID] = Seq(
     "org.apache.spark" %% "spark-core" % sparkCurrentVersion % "provided",
     "org.apache.spark" %% "spark-sql" % sparkCurrentVersion % "provided",
-    "com.typesafe.scala-logging" %% "scala-logging" % TypesafeLoggingVersion,
     "com.exasol" % "exasol-jdbc" % ExasolJdbcVersion
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,7 @@ addSbtPlugin("org.danielnixon" % "sbt-extrawarts" % "1.0.3")
 
 // Adds a `assembly` task to create a fat JAR with all of its dependencies
 // https://github.com/sbt/sbt-assembly
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 
 // Adds a `BuildInfo` tasks
 // https://github.com/sbt/sbt-buildinfo
@@ -32,7 +32,7 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 
 // Adds a `dependencyUpdates` task to check Maven repositories for dependency updates
 // http://github.com/rtimush/sbt-updates
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.4.1")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.4.2")
 
 // Adds a `scalafmt` task for automatic source code formatting
 // https://github.com/lucidsoftware/neo-sbt-scalafmt

--- a/src/it/java/org/testcontainers/containers/ExasolDockerContainer.java
+++ b/src/it/java/org/testcontainers/containers/ExasolDockerContainer.java
@@ -9,7 +9,7 @@ import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 public class ExasolDockerContainer<SELF extends ExasolDockerContainer<SELF>> extends
 JdbcDatabaseContainer<SELF> {
   public static final String EXASOL_IMAGE = "exasol/docker-db";
-  public static final String EXASOL_VERSION = "6.0.13-d1";
+  public static final String EXASOL_VERSION = "6.1.3-d1";
   public static final String EXASOL_HOST = "192.168.0.2";
   public static final Integer EXASOL_PORT = 8888;
   // wait for 5 minutes to startup

--- a/src/main/scala/com/exasol/spark/DefaultSource.scala
+++ b/src/main/scala/com/exasol/spark/DefaultSource.scala
@@ -12,9 +12,10 @@ import com.exasol.spark.util.Types
 import com.exasol.spark.writer.ExasolWriter
 
 /**
- * A data source for creating integration between Exasol and Spark
+ * The default entry source for creating integration between Exasol and Spark.
  *
- * It also serves as a factory class to create [[ExasolRelation]] instances for Spark application.
+ * Additionally, it serves as a factory class to create [[ExasolRelation]]
+ * instances for Spark application.
  */
 class DefaultSource
     extends RelationProvider
@@ -25,13 +26,15 @@ class DefaultSource
   override def shortName(): String = "exasol"
 
   /**
-   * Creates an [[ExasolRelation]] using provided Spark [[org.apache.spark.sql.SQLContext]] and
-   * parameters
+   * Creates an [[ExasolRelation]] using provided Spark
+   * [[org.apache.spark.sql.SQLContext]] and parameters.
    *
-   * The schema is inferred by running the Exasol query with `LIMIT 1` clause.
+   * Since the '''schema''' is not provided, it is inferred by running an Exasol
+   * query with `LIMIT 1` clause.
    *
    * @param sqlContext A Spark [[org.apache.spark.sql.SQLContext]] context
-   * @param parameters The parameters provided as options, `query` parameter is required for read
+   * @param parameters The parameters provided as options, `query` parameter is
+   *        required for read
    * @return An [[ExasolRelation]] relation
    */
   override def createRelation(
@@ -44,12 +47,14 @@ class DefaultSource
   }
 
   /**
-   * Creates an [[ExasolRelation]] using the provided Spark [[org.apache.spark.sql.SQLContext]],
-   * parameters and schema
+   * Creates an [[ExasolRelation]] using the provided Spark
+   * [[org.apache.spark.sql.SQLContext]], parameters and schema.
    *
    * @param sqlContext A Spark [[org.apache.spark.sql.SQLContext]] context
-   * @param parameters The parameters provided as options, `query` parameter is required for read
-   * @param schema A user provided schema used to select columns for the relation
+   * @param parameters The parameters provided as options, `query` parameter is
+   *        required for read
+   * @param schema A user provided schema used to select columns for the
+   *        relation
    * @return An [[ExasolRelation]] relation
    */
   override def createRelation(
@@ -63,12 +68,15 @@ class DefaultSource
   }
 
   /**
-   * Creates an [[ExasolRelation]] after saving a Spark dataframe into Exasol table
+   * Creates an [[ExasolRelation]] after saving a
+   * [[org.apache.spark.sql.DataFrame]] into Exasol table.
    *
    * @param sqlContext A Spark [[org.apache.spark.sql.SQLContext]] context
    * @param mode One of Spark save modes, [[org.apache.spark.sql.SaveMode]]
-   * @param parameters The parameters provided as options, `table` parameter is required for write
-   * @param data A Spark [[org.apache.spark.sql.DataFrame]] to save as a Exasol table
+   * @param parameters The parameters provided as options, `table` parameter is
+   *        required for write
+   * @param data A Spark [[org.apache.spark.sql.DataFrame]] to save as a Exasol
+   *        table
    * @return An [[ExasolRelation]] relation
    */
   override def createRelation(
@@ -119,7 +127,7 @@ class DefaultSource
     createRelation(sqlContext, newParams, data.schema)
   }
 
-  def saveDFTable(
+  private[this] def saveDFTable(
     sqlContext: SQLContext,
     df: DataFrame,
     tableName: String,
@@ -132,7 +140,11 @@ class DefaultSource
     newDF.rdd.foreachPartition(iter => writer.insertPartition(iter))
   }
 
-  def createDFTable(df: DataFrame, tableName: String, manager: ExasolConnectionManager): Unit = {
+  private[this] def createDFTable(
+    df: DataFrame,
+    tableName: String,
+    manager: ExasolConnectionManager
+  ): Unit = {
     if (!manager.config.create_table) {
       throw new UnsupportedOperationException(
         s"""
@@ -152,7 +164,7 @@ class DefaultSource
   }
 
   /**
-   * Rearrange dataframe partitions into Exasol nodes number
+   * Rearrange dataframe partitions into Exasol data nodes count.
    *
    * If `nodesCnt` < `df.rdd.getNumPartitions` then perform
    *
@@ -171,7 +183,6 @@ class DefaultSource
    * so that there a partition for each data node.
    *
    * If the number of partitions and nodes are same, then do nothing.
-   *
    */
   def repartitionPerNode(df: DataFrame, nodesCnt: Int): DataFrame = {
     val rddPartitionCnt = df.rdd.getNumPartitions
@@ -193,7 +204,7 @@ class DefaultSource
         )
     }
 
-  // Creates an ExasolConnectionManager with merged configuration values
+  // Creates an ExasolConnectionManager with merged configuration values.
   private[this] def createManager(
     parameters: Map[String, String],
     sqlContext: SQLContext
@@ -202,8 +213,9 @@ class DefaultSource
     ExasolConnectionManager(config)
   }
 
-  // Merges user provided parameters with `spark.exasol.*` runtime configurations. If both of them
-  // define a key=value pair, then the one provided at runtime is used.
+  // Merges user provided parameters with `spark.exasol.*` runtime
+  // configurations. If both of them define a key=value pair, then the one
+  // provided at runtime is used.
   private[spark] def mergeConfigurations(
     parameters: Map[String, String],
     sparkConf: Map[String, String]

--- a/src/main/scala/com/exasol/spark/ExasolRelation.scala
+++ b/src/main/scala/com/exasol/spark/ExasolRelation.scala
@@ -1,5 +1,6 @@
 package com.exasol.spark
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.SQLContext
@@ -15,8 +16,6 @@ import com.exasol.spark.util.ExasolConnectionManager
 import com.exasol.spark.util.Filters
 import com.exasol.spark.util.Types
 
-import com.typesafe.scalalogging.LazyLogging
-
 class ExasolRelation(
   context: SQLContext,
   queryString: String,
@@ -26,7 +25,7 @@ class ExasolRelation(
     with PrunedFilteredScan
     with PrunedScan
     with TableScan
-    with LazyLogging {
+    with Logging {
 
   override def sqlContext: SQLContext = context
 
@@ -44,7 +43,7 @@ class ExasolRelation(
   }
 
   override def schema: StructType = configSchema.fold(inferSchema) { userSchema =>
-    logger.info(s"Using provided schema $userSchema")
+    logInfo(s"Using provided schema $userSchema")
     userSchema
   }
 
@@ -106,7 +105,7 @@ class ExasolRelation(
     val filterStr = Filters.createWhereClause(schema, filters)
     val whereClause = if (filterStr.trim.isEmpty) "" else s"WHERE $filterStr"
     val enrichedQuery = s"SELECT $columnStr FROM ($queryString) A $whereClause"
-    logger.info(s"Running with enriched query: $enrichedQuery")
+    logInfo(s"Running with enriched query: $enrichedQuery")
     enrichedQuery
   }
 

--- a/src/main/scala/com/exasol/spark/ExasolWriter.scala
+++ b/src/main/scala/com/exasol/spark/ExasolWriter.scala
@@ -14,8 +14,6 @@ import com.exasol.spark.util.Converter
 import com.exasol.spark.util.ExasolConnectionManager
 import com.exasol.spark.util.Types
 
-import com.typesafe.scalalogging.LazyLogging
-
 /**
  *
  */
@@ -24,8 +22,7 @@ class ExasolWriter(
   tableName: String,
   rddSchema: StructType,
   manager: ExasolConnectionManager
-) extends Serializable
-    with LazyLogging {
+) extends Serializable {
 
   // scalastyle:off null
   @transient private var mainConnection: EXAConnection = null
@@ -41,12 +38,10 @@ class ExasolWriter(
     mainConnection = manager.writerMainConnection()
 
     if (mainConnection == null) {
-      logger.error("Could not create main connection!")
       throw new RuntimeException("Could not create main connection to Exasol!")
     }
 
     val cnt = manager.initParallel(mainConnection)
-    logger.info(s"Initiated $cnt parallel sub connections")
 
     // Close Exasol main connection when SparkContext finishes. This is a lifetime of a Spark
     // application.
@@ -107,15 +102,12 @@ class ExasolWriter(
         val _ = stmt.executeBatch()
         totalCnt += rowCnt
       }
-      logger.info(s"Inserted in total $totalCnt rows into table $tableName")
 
       ()
     } catch {
       case ex: SQLException =>
-        logger.error(s"Error during statement batch execution ${ex.printStackTrace()}")
         throw ex
     } finally {
-      logger.info("Closing sub connection statement and connection")
       stmt.close()
       subConn.commit()
       subConn.close()

--- a/src/main/scala/com/exasol/spark/rdd/ExasolRDD.scala
+++ b/src/main/scala/com/exasol/spark/rdd/ExasolRDD.scala
@@ -21,10 +21,10 @@ import com.exasol.spark.util.Converter
 import com.exasol.spark.util.ExasolConnectionManager
 
 /**
- * An [[org.apache.spark.rdd.RDD]] reads / writes data from an Exasol tables
+ * An [[org.apache.spark.rdd.RDD]] reads / writes data from an Exasol tables.
  *
- * The [[com.exasol.spark.rdd.ExasolRDD]] holds data in parallel from each Exasol physical nodes.
- *
+ * The [[com.exasol.spark.rdd.ExasolRDD]] holds data in parallel from each
+ * Exasol physical nodes.
  */
 class ExasolRDD(
   @transient val sc: SparkContext,
@@ -62,8 +62,8 @@ class ExasolRDD(
     val cnt = manager.initParallel(conn)
     logInfo(s"Initiated $cnt parallel exasol (sub) connections")
 
-    // Close Exasol main connection when SparkContext finishes. This is a lifetime of a Spark
-    // application.
+    // Close Exasol main connection when SparkContext finishes. This is a
+    // lifetime of a Spark application.
     sc.addSparkListener(new SparkListener {
       override def onApplicationEnd(appEnd: SparkListenerApplicationEnd): Unit =
         closeMainResources()

--- a/src/main/scala/com/exasol/spark/rdd/ExasolRDD.scala
+++ b/src/main/scala/com/exasol/spark/rdd/ExasolRDD.scala
@@ -8,6 +8,7 @@ import scala.util.control.NonFatal
 import org.apache.spark.Partition
 import org.apache.spark.SparkContext
 import org.apache.spark.TaskContext
+import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.scheduler.SparkListener
 import org.apache.spark.scheduler.SparkListenerApplicationEnd
@@ -18,8 +19,6 @@ import com.exasol.jdbc.EXAConnection
 import com.exasol.jdbc.EXAResultSet
 import com.exasol.spark.util.Converter
 import com.exasol.spark.util.ExasolConnectionManager
-
-import com.typesafe.scalalogging.LazyLogging
 
 /**
  * An [[org.apache.spark.rdd.RDD]] reads / writes data from an Exasol tables
@@ -33,7 +32,7 @@ class ExasolRDD(
   querySchema: StructType,
   manager: ExasolConnectionManager
 ) extends RDD[Row](sc, Nil)
-    with LazyLogging {
+    with Logging {
 
   // scalastyle:off null
   @transient private var mainConnection: EXAConnection = null
@@ -56,12 +55,12 @@ class ExasolRDD(
   def createMainConnection(): EXAConnection = {
     val conn = manager.mainConnection()
     if (conn == null) {
-      logger.error("Main EXAConnection is null!")
+      logError("Main EXAConnection is null!")
       throw new RuntimeException("Could not establish main connection to Exasol!")
     }
 
     val cnt = manager.initParallel(conn)
-    logger.info(s"Initiated $cnt parallel exasol (sub) connections")
+    logInfo(s"Initiated $cnt parallel exasol (sub) connections")
 
     // Close Exasol main connection when SparkContext finishes. This is a lifetime of a Spark
     // application.
@@ -86,7 +85,7 @@ class ExasolRDD(
       .zipWithIndex
       .map { case (url, idx) => ExasolRDDPartition(idx, handle, url) }
 
-    logger.info(s"The number of partitions is ${partitions.size}")
+    logInfo(s"The number of partitions is ${partitions.size}")
 
     partitions.toArray
   }
@@ -109,7 +108,7 @@ class ExasolRDD(
           resultSet.close()
         }
       } catch {
-        case e: Exception => logger.warn("Received an exception closing sub resultSet", e)
+        case e: Exception => logWarning("Received an exception closing sub resultSet", e)
       }
 
       try {
@@ -117,7 +116,7 @@ class ExasolRDD(
           stmt.close()
         }
       } catch {
-        case e: Exception => logger.warn("Received an exception closing sub statement", e)
+        case e: Exception => logWarning("Received an exception closing sub statement", e)
       }
 
       try {
@@ -126,14 +125,14 @@ class ExasolRDD(
             try {
               conn.commit()
             } catch {
-              case NonFatal(e) => logger.warn("Received exception committing sub connection", e)
+              case NonFatal(e) => logWarning("Received exception committing sub connection", e)
             }
           }
           conn.close()
-          logger.info("Closed a sub connection")
+          logInfo("Closed a sub connection")
         }
       } catch {
-        case e: Exception => logger.warn("Received an exception closing sub connection", e)
+        case e: Exception => logWarning("Received an exception closing sub connection", e)
       }
 
       closed = true
@@ -146,10 +145,10 @@ class ExasolRDD(
     val partition: ExasolRDDPartition = split.asInstanceOf[ExasolRDDPartition]
     val subHandle: Int = partition.handle
 
-    logger.info(s"Sub connection with url = ${partition.connectionUrl} and handle = $subHandle")
+    logInfo(s"Sub connection with url = ${partition.connectionUrl} and handle = $subHandle")
 
     if (subHandle == -1) {
-      logger.info("Sub connection handle is -1, no results, return empty iterator")
+      logInfo("Sub connection handle is -1, no results, return empty iterator")
       return Iterator.empty
     }
 

--- a/src/main/scala/com/exasol/spark/rdd/ExasolRDDPartition.scala
+++ b/src/main/scala/com/exasol/spark/rdd/ExasolRDDPartition.scala
@@ -3,15 +3,15 @@ package com.exasol.spark.rdd
 import org.apache.spark.Partition
 
 /**
- * A class that holds [[com.exasol.spark.rdd.ExasolRDD]] partition information
+ * A class that holds [[com.exasol.spark.rdd.ExasolRDD]] partition information.
  *
- * Each partition is mapped to a single Exasol node. The [[com.exasol.spark.rdd.ExasolRDD]]
- * materializes the data of a node based on the information represented by a partition.
+ * Each partition is mapped to a single Exasol node. The
+ * [[com.exasol.spark.rdd.ExasolRDD]] materializes the data of a node based on
+ * the information represented by a partition.
  *
  * @param idx A partition identifier (0 based)
  * @param handle A Exasol sub connection query identifier handle
  * @param connectionUrl An exasol jdbc (sub) connection string
- *
  */
 final case class ExasolRDDPartition(val idx: Int, val handle: Int, val connectionUrl: String)
     extends Partition {

--- a/src/main/scala/com/exasol/spark/util/Converter.scala
+++ b/src/main/scala/com/exasol/spark/util/Converter.scala
@@ -3,6 +3,7 @@ package com.exasol.spark.util
 import java.sql.PreparedStatement
 import java.sql.ResultSet
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
@@ -11,8 +12,6 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
-import com.typesafe.scalalogging.LazyLogging
-
 /**
  * A helper class with functions to convert JDBC ResultSet to/from Spark Row
  *
@@ -20,7 +19,7 @@ import com.typesafe.scalalogging.LazyLogging
  *  - org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
  *
  */
-object Converter extends LazyLogging {
+object Converter extends Logging {
 
   /**
    * Converts a [[java.sql.ResultSet]] into an iterator of [[org.apache.spark.sql.Row]]-s
@@ -44,7 +43,7 @@ object Converter extends LazyLogging {
       try {
         rs.close()
       } catch {
-        case e: Exception => logger.warn("Exception closing resultset", e)
+        case e: Exception => logWarning("Exception closing resultset", e)
       }
 
     override protected def getNext(): InternalRow =

--- a/src/main/scala/com/exasol/spark/util/Converter.scala
+++ b/src/main/scala/com/exasol/spark/util/Converter.scala
@@ -13,16 +13,17 @@ import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
 /**
- * A helper class with functions to convert JDBC ResultSet to/from Spark Row
+ * A helper object with functions to convert JDBC [[java.sql.ResultSet]] into
+ * Spark [[org.apache.spark.sql.Row]] or vice versa.
  *
- * Most of the functions here are adapted from Spark JdbcUtils class,
- *  - org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
- *
+ * Most of the functions here are adapted from
+ * `spark/sql/execution/datasources/jdbc/JdbcUtils.scala` class.
  */
 object Converter extends Logging {
 
   /**
-   * Converts a [[java.sql.ResultSet]] into an iterator of [[org.apache.spark.sql.Row]]-s
+   * Converts a [[java.sql.ResultSet]] into an iterator of
+   * [[org.apache.spark.sql.Row]]-s.
    */
   def resultSetToRows(resultSet: ResultSet, schema: StructType): Iterator[Row] = {
     val encoder = RowEncoder(schema).resolveAndBind()
@@ -61,15 +62,16 @@ object Converter extends Logging {
       }
   }
 
-  // A `JDBCValueGetter` is responsible for getting a value from `ResultSet` into a field for
-  // `MutableRow`. The last argument `Int` means the index for the value to be set in the row and
-  // also used for the value in `ResultSet`.
+  // A `JDBCValueGetter` is responsible for getting a value from `ResultSet`
+  // into a field for `MutableRow`. The last argument `Int` means the index for
+  // the value to be set in the row and also used for the value in `ResultSet`.
   private type JDBCValueGetter = (ResultSet, InternalRow, Int) => Unit
 
   /**
-   * Creates `JDBCValueGetter`s according to [[org.apache.spark.sql.types.StructType]], which can
-   * set each value from `ResultSet` to each field of
-   * [[org.apache.spark.sql.catalyst.InternalRow]] correctly.
+   * Creates `JDBCValueGetter`s according to
+   * [[org.apache.spark.sql.types.StructType]], which can set each value from
+   * `ResultSet` to each field of [[org.apache.spark.sql.catalyst.InternalRow]]
+   * correctly.
    */
   private def makeGetters(schema: StructType): Array[JDBCValueGetter] =
     schema.fields.map(sf => makeGetter(sf.dataType, sf.metadata))
@@ -82,7 +84,8 @@ object Converter extends Logging {
 
     case DateType =>
       (rs: ResultSet, row: InternalRow, pos: Int) =>
-        // DateTimeUtils.fromJavaDate does not handle null value, so we need to check it.
+        // DateTimeUtils.fromJavaDate does not handle null value, so we need to
+        // check it.
         val dateVal = rs.getDate(pos + 1)
         if (dateVal != null) {
           row.setInt(pos, DateTimeUtils.fromJavaDate(dateVal))
@@ -162,9 +165,10 @@ object Converter extends Logging {
     }
   // scalastyle:on null
 
-  // A `JDBCValueSetter` is responsible for setting a value from `Row` into a field for
-  // `PreparedStatement`. The last argument `Int` means the index for the value to be set in the
-  // SQL statement and also used for the value in `Row`.
+  // A `JDBCValueSetter` is responsible for setting a value from `Row` into a
+  // field for `PreparedStatement`. The last argument `Int` means the index for
+  // the value to be set in the SQL statement and also used for the value in
+  // `Row`.
   private[spark] type JDBCValueSetter = (PreparedStatement, Row, Int) => Unit
 
   private[spark] def makeSetter(dataType: DataType): JDBCValueSetter = dataType match {

--- a/src/main/scala/com/exasol/spark/util/ExasolConfiguration.scala
+++ b/src/main/scala/com/exasol/spark/util/ExasolConfiguration.scala
@@ -5,10 +5,9 @@ import java.net.InetAddress
 import scala.util.matching.Regex
 
 /**
- * The configuration parameters for Spark Exasol connector
+ * The configuration parameters for Spark Exasol connector.
  *
  * These can be user provided when loading or defined in Spark configurations.
- *
  * For example, user provided:
  *
  * {{{
@@ -37,9 +36,8 @@ import scala.util.matching.Regex
  *      .getOrCreate()
  * }}}
  *
- * If both are defined, spark configs are used. If nothing is defined, then default values are
- * used.
- *
+ * If both are defined, spark configs are used. If nothing is defined, then
+ * default values are used.
  */
 final case class ExasolConfiguration(
   host: String,

--- a/src/main/scala/com/exasol/spark/util/ExasolConnectionManager.scala
+++ b/src/main/scala/com/exasol/spark/util/ExasolConnectionManager.scala
@@ -5,11 +5,11 @@ import java.util.concurrent.ConcurrentHashMap
 
 import scala.util.Try
 
+import org.apache.spark.internal.Logging
+
 import com.exasol.jdbc.EXAConnection
 import com.exasol.jdbc.EXAResultSet
 import com.exasol.jdbc.EXAStatement
-
-import com.typesafe.scalalogging.LazyLogging
 
 /**
  * A class that provides and manages Exasol connections
@@ -189,7 +189,7 @@ final case class ExasolConnectionManager(config: ExasolConfiguration) {
  * The companion object to [[ExasolConnectionManager]]
  *
  */
-object ExasolConnectionManager extends LazyLogging {
+object ExasolConnectionManager extends Logging {
 
   private[this] val JDBC_LOGIN_TIMEOUT: Int = 30
 
@@ -211,13 +211,13 @@ object ExasolConnectionManager extends LazyLogging {
   private[this] def removeIfClosed(url: String): Unit = {
     val conn = connections.get(url)
     if (conn != null && conn.isClosed) {
-      logger.info(s"Connection $url is closed, removing it from the pool")
+      logInfo(s"Connection $url is closed, removing it from the pool")
       val _ = connections.remove(url)
     }
   }
 
   def makeConnection(url: String, username: String, password: String): EXAConnection = {
-    logger.debug(s"Making a connection using url = $url")
+    logDebug(s"Making a connection using url = $url")
     removeIfClosed(url)
     if (!connections.containsKey(url)) {
       val _ = connections.put(url, createConnection(url, username, password))

--- a/src/main/scala/com/exasol/spark/util/ExasolConnectionManager.scala
+++ b/src/main/scala/com/exasol/spark/util/ExasolConnectionManager.scala
@@ -12,13 +12,13 @@ import com.exasol.jdbc.EXAResultSet
 import com.exasol.jdbc.EXAStatement
 
 /**
- * A class that provides and manages Exasol connections
+ * A class that provides and manages Exasol connections.
  *
- * It is okay to serialize this class to Spark workers, it will create Exasol jdbc connections
- * within each executor JVM.
+ * It is okay to serialize this class to Spark workers, it will create Exasol
+ * jdbc connections within each executor JVM.
  *
- * @param config An [[ExasolConfiguration]] with user provided or runtime configuration parameters
- *
+ * @param config An [[ExasolConfiguration]] with user provided or runtime
+ *        configuration parameters
  */
 final case class ExasolConnectionManager(config: ExasolConfiguration) {
 
@@ -40,9 +40,10 @@ final case class ExasolConnectionManager(config: ExasolConfiguration) {
     )
 
   /**
-   * A single non-pooled [[com.exasol.jdbc.EXAConnection]] connection
+   * A single non-pooled [[com.exasol.jdbc.EXAConnection]] connection.
    *
-   * Maintaining and gracefully closing the connection is a responsibility of the user.
+   * Maintaining and gracefully closing the connection is a responsibility of
+   * the user.
    */
   def getConnection(): EXAConnection =
     ExasolConnectionManager.createConnection(
@@ -70,27 +71,25 @@ final case class ExasolConnectionManager(config: ExasolConfiguration) {
     ExasolConnectionManager.makeConnection(subConnectionUrl, config.username, config.password)
 
   /**
-   * A method to run with a new connection
+   * A method to run with a new connection.
    *
    * This method closes the connection afterwards.
    *
    * @param handle A code block that needs to be run with a connection
    * @tparam T A result type of the `handle` function
    * @return A result of `handle` function
-   *
    */
   def withConnection[T](handle: EXAConnection => T): T =
     ExasolConnectionManager.using(getConnection)(handle)
 
   /**
-   * A helper method to run with a new statement
+   * A helper method to run with a new statement.
    *
    * This method closes the resources afterwards.
    *
    * @param handle A code block that needs to be run with a given statement
    * @tparam T A result type of the `handle` function
    * @return A result of `handle` function
-   *
    */
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def withStatement[T](handle: EXAStatement => T): T = withConnection[T] { conn =>
@@ -99,11 +98,10 @@ final case class ExasolConnectionManager(config: ExasolConfiguration) {
   }
 
   /**
-   * A helper method to run `stmt.execute` given a list of queries
+   * A helper method to run `stmt.execute` given a list of queries.
    *
    * @param queries A list of SQL queries to run
    * @return A [[scala.Unit]] result
-   *
    */
   def withExecute(queries: Seq[String]): Unit = withStatement[Unit] { stmt =>
     queries.foreach { query =>
@@ -113,12 +111,11 @@ final case class ExasolConnectionManager(config: ExasolConfiguration) {
   }
 
   /**
-   * A helper method to run `stmt.executeQuery` given a query
+   * A helper method to run `stmt.executeQuery` given a query.
    *
    * @param query A query string to executeQuery
    * @tparam T A result type of the `handle` function
    * @return A result of `handle` function
-   *
    */
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def withExecuteQuery[T](query: String)(handle: EXAResultSet => T): T = withStatement[T] {
@@ -127,7 +124,7 @@ final case class ExasolConnectionManager(config: ExasolConfiguration) {
       ExasolConnectionManager.using(rs)(handle)
   }
 
-  /** Given a query with `count(*)` returns the result */
+  /** Given a query with `count(*)` returns the result. */
   def withCountQuery(query: String): Long = withExecuteQuery[Long](query) { rs =>
     val cnt = if (rs.next()) {
       rs.getLong(1)
@@ -138,14 +135,14 @@ final case class ExasolConnectionManager(config: ExasolConfiguration) {
   }
 
   /**
-   * Checks if table already exists, if so should return true otherwise false
+   * Checks if table already exists, if so should return true otherwise false.
    *
-   * TODO: This should be changed to Exasol specific checks. For example, by using
-   *       EXA_USER_TABLES.
+   * TODO: This should be changed to Exasol specific checks. For example, by
+   *       using EXA_USER_TABLES.
    *
-   * @param tableName A Exasol table name including schema, e.g. `schema.tableName`
-   * @return A boolean, true if table exists
-   *
+   * @param tableName A Exasol table name including schema, e.g.
+   *        `schema.tableName`
+   * @return `true` if table exists, otherwise return `false`
    */
   def tableExists(tableName: String): Boolean = withConnection[Boolean] { conn =>
     val tryEither = Try {
@@ -160,22 +157,29 @@ final case class ExasolConnectionManager(config: ExasolConfiguration) {
     tryEither.isSuccess
   }
 
-  /** Given an Exasol table name (with schema, e.g mySchema.myTable format), truncates it */
+  /**
+   * Given an Exasol table name (with schema, e.g mySchema.myTable format),
+   * truncates it.
+   */
   def truncateTable(tableName: String): Unit = withStatement[Unit] { stmt =>
     val _ = stmt.executeUpdate(s"TRUNCATE TABLE $tableName")
     ()
   }
 
-  /** Given an Exasol table name (with schema, e.g mySchema.myTable format), drop it */
+  /**
+   * Given an Exasol table name (with schema, e.g mySchema.myTable format), drop
+   * it.
+   */
   def dropTable(tableName: String): Unit = withStatement[Unit] { stmt =>
     val _ = stmt.executeUpdate(s"DROP TABLE IF EXISTS $tableName")
     ()
   }
 
   /**
-   * Creates a table in Exasol
+   * Creates a table in Exasol.
    *
-   * @param tableName A table name (with both schema and table, e.g. myschem.my_table)
+   * @param tableName A table name (with both schema and table, e.g.
+   *        myschem.my_table)
    * @param tabelSchema A schema string of table with column names and types
    */
   def createTable(tableName: String, tableSchema: String): Unit = withStatement[Unit] { stmt =>
@@ -186,8 +190,7 @@ final case class ExasolConnectionManager(config: ExasolConfiguration) {
 }
 
 /**
- * The companion object to [[ExasolConnectionManager]]
- *
+ * The companion object to [[ExasolConnectionManager]].
  */
 object ExasolConnectionManager extends Logging {
 

--- a/src/main/scala/com/exasol/spark/util/Filters.scala
+++ b/src/main/scala/com/exasol/spark/util/Filters.scala
@@ -3,13 +3,11 @@ package com.exasol.spark.util
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
 
-import com.typesafe.scalalogging.LazyLogging
-
 /**
  * A helper class with functions to create Exasol where clauses from Spark
  * [[org.apache.spark.sql.sources.Filter]]-s
  */
-object Filters extends LazyLogging {
+object Filters {
 
   /**
    * Creates an Exasol SQL where clause from given list of

--- a/src/main/scala/com/exasol/spark/util/Filters.scala
+++ b/src/main/scala/com/exasol/spark/util/Filters.scala
@@ -5,14 +5,14 @@ import org.apache.spark.sql.types._
 
 /**
  * A helper class with functions to create Exasol where clauses from Spark
- * [[org.apache.spark.sql.sources.Filter]]-s
+ * [[org.apache.spark.sql.sources.Filter]]-s.
  */
 object Filters {
 
   /**
    * Creates an Exasol SQL where clause from given list of
-   * [[org.apache.spark.sql.sources.Filter]]-s. Then these set of predicates will be pushed to
-   * Exasol for evaluation.
+   * [[org.apache.spark.sql.sources.Filter]]-s. Then these set of predicates
+   * will be pushed to Exasol for evaluation.
    *
    * @param schema A user provided or inferred schema of the query
    * @param filters A sequence of Spark source filters
@@ -25,8 +25,11 @@ object Filters {
   }
 
   /**
-   * Given a Spark source [[org.apache.spark.sql.sources.Filter]], create a Exasol SQL expression.
-   * Returns [[scala.None]] if an expression could not be created from the filter.
+   * Given a Spark source [[org.apache.spark.sql.sources.Filter]], create a
+   * Exasol SQL expression.
+   *
+   * Returns [[scala.None]] if an expression could not be created from the
+   * filter.
    */
   def filterExpr(filter: Filter, dataTypes: Map[String, DataType]): Option[String] =
     filter match {

--- a/src/main/scala/com/exasol/spark/util/NextIterator.scala
+++ b/src/main/scala/com/exasol/spark/util/NextIterator.scala
@@ -20,9 +20,9 @@ package com.exasol.spark.util
 /**
  * Provides a basic/boilerplate Iterator implementation.
  *
- * This is adapted from Spark codebase, [[org.apache.spark.util.NextIterator]]. It is private
- * internally in Spark, copied here to be used in [[com.exasol.spark.rdd.ExasolRDD]].
- *
+ * This is adapted from Spark codebase, [[org.apache.spark.util.NextIterator]].
+ * It is private internally in Spark, copied here to be used in
+ * [[com.exasol.spark.rdd.ExasolRDD]].
  */
 private[spark] abstract class NextIterator[U] extends Iterator[U] {
 
@@ -34,12 +34,12 @@ private[spark] abstract class NextIterator[U] extends Iterator[U] {
   /**
    * Method for subclasses to implement to provide the next element.
    *
-   * If no next element is available, the subclass should set `finished`
-   * to `true` and may return any value (it will be ignored).
+   * If no next element is available, the subclass should set `finished` to
+   * `true` and may return any value (it will be ignored).
    *
-   * This convention is required because `null` may be a valid value,
-   * and using `Option` seems like it might create unnecessary Some/None
-   * instances, given some iterators might be called in a tight loop.
+   * This convention is required because `null` may be a valid value, and using
+   * `Option` seems like it might create unnecessary Some/None instances, given
+   * some iterators might be called in a tight loop.
    *
    * @return U, or set 'finished' when done
    */
@@ -49,12 +49,12 @@ private[spark] abstract class NextIterator[U] extends Iterator[U] {
    * Method for subclasses to implement when all elements have been successfully
    * iterated, and the iteration is done.
    *
-   * <b>Note:</b> `NextIterator` cannot guarantee that `close` will be
-   * called because it has no control over what happens when an exception
-   * happens in the user code that is calling hasNext/next.
+   * <b>Note:</b> `NextIterator` cannot guarantee that `close` will be called
+   * because it has no control over what happens when an exception happens in
+   * the user code that is calling hasNext/next.
    *
-   * Ideally you should have another try/catch, as in HadoopRDD, that
-   * ensures any resources are closed should iteration fail.
+   * Ideally you should have another try/catch, as in HadoopRDD, that ensures
+   * any resources are closed should iteration fail.
    */
   protected def close(): Unit
 
@@ -66,8 +66,9 @@ private[spark] abstract class NextIterator[U] extends Iterator[U] {
    */
   def closeIfNeeded(): Unit =
     if (!closed) {
-      // Note: it's important that we set closed = true before calling close(), since setting it
-      // afterwards would permit us to call close() multiple times if close() threw an exception.
+      // Note: it's important that we set closed = true before calling close(),
+      // since setting it afterwards would permit us to call close() multiple
+      // times if close() threw an exception.
       closed = true
       close()
     }

--- a/src/main/scala/com/exasol/spark/util/Types.scala
+++ b/src/main/scala/com/exasol/spark/util/Types.scala
@@ -2,12 +2,11 @@ package com.exasol.spark.util
 
 import java.sql.ResultSetMetaData
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.types._
 
-import com.typesafe.scalalogging.LazyLogging
-
 /** A helper class with mapping functions from Exasol JDBC types to/from Spark SQL types */
-object Types extends LazyLogging {
+object Types extends Logging {
 
   private val MAX_PRECISION_EXASOL: Int = 36
   private val MAX_SCALE_EXASOL: Int = 36
@@ -203,7 +202,7 @@ object Types extends LazyLogging {
     val fieldsNames = schema.fieldNames.toSet
     val newFields = columns.filter(fieldsNames.contains(_)).map(schema(_))
     val newSchema = StructType(newFields)
-    logger.debug(s"Using a new pruned schema $newSchema")
+    logDebug(s"Using a new pruned schema $newSchema")
     newSchema
   }
 

--- a/src/main/scala/com/exasol/spark/util/Types.scala
+++ b/src/main/scala/com/exasol/spark/util/Types.scala
@@ -5,7 +5,10 @@ import java.sql.ResultSetMetaData
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.types._
 
-/** A helper class with mapping functions from Exasol JDBC types to/from Spark SQL types */
+/**
+ * A helper class with mapping functions between Exasol JDBC types and Spark SQL
+ * types.
+ */
 object Types extends Logging {
 
   private val MAX_PRECISION_EXASOL: Int = 36
@@ -15,7 +18,7 @@ object Types extends Logging {
 
   /**
    * Given a [[java.sql.ResultSetMetaData]] returns a Spark
-   * [[org.apache.spark.sql.types.StructType]] schema
+   * [[org.apache.spark.sql.types.StructType]] schema.
    *
    * @param rsmd A result set metadata
    * @return A StructType matching result set types
@@ -42,12 +45,16 @@ object Types extends Logging {
   }
 
   /**
-   * Maps a JDBC type [[java.sql.Types$]] to a Spark SQL [[org.apache.spark.sql.types.DataType]]
+   * Maps a JDBC type [[java.sql.Types$]] to a Spark SQL
+   * [[org.apache.spark.sql.types.DataType]].
    *
    * @param sqlType A JDBC type from [[java.sql.ResultSetMetaData]] column type
-   * @param precision A precision value obtained from ResultSetMetaData, rsmd.getPrecision(index)
-   * @param scale A scale value obtained from ResultSetMetaData, rsmd.getScale(index)
-   * @param isSigned A isSigned value obtained from ResultSetMetaData, rsmd.isSigned(index)
+   * @param precision A precision value obtained from ResultSetMetaData,
+   *        `rsmd.getPrecision(index)`
+   * @param scale A scale value obtained from ResultSetMetaData,
+   *        `rsmd.getScale(index)`
+   * @param isSigned A isSigned value obtained from ResultSetMetaData,
+   *        `rsmd.isSigned(index)`
    * @return A Spark SQL DataType corresponding to JDBC SQL type
    */
   def createSparkTypeFromSQLType(
@@ -117,8 +124,8 @@ object Types extends Logging {
   }
 
   /**
-   * Bound DecimalType within Spark [[DecimalType.MAX_PRECISION]] and [[DecimalType.MAX_SCALE]]
-   * values
+   * Bounds DecimalType within Spark [[DecimalType.MAX_PRECISION]] and
+   * [[DecimalType.MAX_SCALE]] values.
    */
   private[this] def boundedDecimal(precision: Int, scale: Int): DecimalType =
     DecimalType(
@@ -128,9 +135,10 @@ object Types extends Logging {
 
   /**
    * Returns corresponding Jdbc [[java.sql.Types$]] type given Spark
-   * [[org.apache.spark.sql.types.DataType]] type
+   * [[org.apache.spark.sql.types.DataType]] type.
    *
-   * @param dataType A Spark DataType (e.g. [[org.apache.spark.sql.types.StringType$]])
+   * @param dataType A Spark DataType (e.g.
+   *        [[org.apache.spark.sql.types.StringType$]])
    * @return A default JdbcType for this DataType
    */
   def jdbcTypeFromSparkDataType(dataType: DataType): Int = dataType match {
@@ -151,12 +159,10 @@ object Types extends Logging {
 
   /**
    * Returns corresponding Exasol type as a string for a given Spark
-   * [[org.apache.spark.sql.types.DataType]] type
+   * [[org.apache.spark.sql.types.DataType]] type.
    *
-   * The types are obtained from Exasol manual, from a table named 'Summary of Exasol aliases',
-   * section 2.3.3 Data Type Aliases.
-   *
-   * @param dataType A Spark DataType (e.g. [[org.apache.spark.sql.types.StringType$]])
+   * @param dataType A Spark DataType (e.g.
+   *        [[org.apache.spark.sql.types.StringType$]])
    * @return A default Exasol type as string for this DataType
    */
   def exasolTypeFromSparkDataType(dataType: DataType): String = dataType match {
@@ -176,13 +182,17 @@ object Types extends Logging {
 
   /**
    * Convert Spark Type with Decimal precision,scale to Exasol type.
-   * Spark.DecimalType(5,2) -> "DECIMAL(5,2)"
    *
-   * Exasol has a max scale, precision of 36.
-   * Spark precision/scale greater than 36 will be truncated.
+   * For example:
+   * {{{
+   *    Spark.DecimalType(5,2) -> "DECIMAL(5,2)"
+   * }}}
    *
-   * @param decimalType  A Spark DecimalType with precision and scale
-   * @return The Equivalent Exasol type
+   * Exasol has a max scale, precision of 36. Spark precision/scale greater than
+   * 36 will be truncated.
+   *
+   * @param decimalType A Spark DecimalType with precision and scale
+   * @return The equivalent Exasol type
    */
   def convertSparkPrecisionScaleToExasol(decimalType: DecimalType): String = {
     val boundedType = boundedDecimal(decimalType.precision, decimalType.scale)
@@ -190,13 +200,14 @@ object Types extends Logging {
   }
 
   /**
-   * Select only required columns from Spark SQL schema
+   * Select only required columns from Spark SQL schema.
    *
    * Adapted from Spark JDBCRDD private function `pruneSchema`.
    *
    * @param columns A list of required columns
    * @param schema A Spark SQL schema
-   * @return A new Spark SQL schema with only columns in the order of column names
+   * @return A new Spark SQL schema with only columns in the order of column
+   *         names
    */
   def selectColumns(columns: Array[String], schema: StructType): StructType = {
     val fieldsNames = schema.fieldNames.toSet
@@ -207,7 +218,8 @@ object Types extends Logging {
   }
 
   /**
-   * Returns comma separated column name and column types for Exasol table from Spark schema
+   * Returns comma separated column name and column types for Exasol table from
+   * Spark schema.
    *
    * @param schema A Spark [[org.apache.spark.sql.types.StructType]] schema
    * @return A comma separated column names and their types


### PR DESCRIPTION
This should fix the issues related to logging in managed Spark deployments, e.g, Azure Databricks.

Additionally, refactors Scaladoc comments.

Fixes #45 .