### PR TITLE
Remove `NOT NULL` constraint from String types.

### DIFF
--- a/src/test/scala/com/exasol/spark/util/TypesSuite.scala
+++ b/src/test/scala/com/exasol/spark/util/TypesSuite.scala
@@ -156,7 +156,7 @@ class TypesSuite extends FunSuite with Matchers {
     )
   }
 
-  test("`createTableSchema` should create a comma separated column names and types") {
+  test("createTableSchema should create a comma separated column names and types") {
     val schema: StructType = StructType(
       Seq(
         StructField("bool_col", BooleanType),
@@ -174,6 +174,17 @@ class TypesSuite extends FunSuite with Matchers {
         " double_col DOUBLE, date_col DATE, timestamp_col TIMESTAMP"
 
     assert(createTableSchema(schema) === expectedStr)
+  }
+
+  test("createTableSchema returns string type without not null constraint") {
+    val schema = StructType(
+      Seq(
+        StructField("str_col", StringType),
+        StructField("text_col", StringType, false)
+      )
+    )
+    val expectedConvertedSchema = "str_col CLOB, text_col CLOB"
+    assert(createTableSchema(schema) === expectedConvertedSchema)
   }
 
 }


### PR DESCRIPTION
We create an Exasol table, if it did not exist, before saving the Spark
dataframe. The `NOT NULL` constraint was added to the create table DDL,
if the Spark schema field type is not nullable.

However, this can be problem in Exasol side. Because, Exasol puts `null`
if the string is empty for `VARCHAR` or `CLOB` column types. Therefore,
putting not null constraints fails when inserting empty strings.

This commit removes the `NOT NULL` constraints from string types even if
they are not nullable.

Fixes #60.