### PR TITLE
Changes Spark to 2.4.5 and Exasol JDBC to 6.2.5 versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,19 +45,19 @@ matrix:
   include:
     - jdk: openjdk8
       scala: 2.11.12
-      env: SPARK_VERSION="2.4.3"
+      env: SPARK_VERSION="2.4.5"
 
     - jdk: oraclejdk8
       scala: 2.11.12
-      env: SPARK_VERSION="2.4.3"
+      env: SPARK_VERSION="2.4.5"
 
     - jdk: openjdk8
-      scala: 2.12.8
-      env: SPARK_VERSION="2.4.3"
+      scala: 2.12.10
+      env: SPARK_VERSION="2.4.5"
 
     - jdk: oraclejdk8
-      scala: 2.12.8
-      env: SPARK_VERSION="2.4.3" RELEASE=false
+      scala: 2.12.10
+      env: SPARK_VERSION="2.4.5" RELEASE=false
 
 script:
   - travis_wait 30 ./scripts/ci.sh

--- a/README.md
+++ b/README.md
@@ -285,13 +285,13 @@ spark-shell --jars /path/to/spark-exasol-connector-assembly-*.jar
   parameter. However, it is not advised to limit this value in production
   environment.
 
-[travis-badge]: https://travis-ci.org/exasol/spark-exasol-connector.svg?branch=master
-[travis-link]: https://travis-ci.org/exasol/spark-exasol-connector
+[travis-badge]: https://travis-ci.com/exasol/spark-exasol-connector.svg?branch=master
+[travis-link]: https://travis-ci.com/exasol/spark-exasol-connector
 [codecov-badge]: https://codecov.io/gh/exasol/spark-exasol-connector/branch/master/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/exasol/spark-exasol-connector
-[maven-img-badge]: https://img.shields.io/maven-central/v/com.exasol/spark-connector_2.11.svg
-[maven-reg-badge]: https://maven-badges.herokuapp.com/maven-central/com.exasol/spark-connector_2.11/badge.svg
-[maven-link]: https://maven-badges.herokuapp.com/maven-central/com.exasol/spark-connector_2.11
+[maven-img-badge]: https://img.shields.io/maven-central/v/com.exasol/spark-connector_2.12.svg
+[maven-reg-badge]: https://maven-badges.herokuapp.com/maven-central/com.exasol/spark-connector_2.12/badge.svg
+[maven-link]: https://maven-badges.herokuapp.com/maven-central/com.exasol/spark-connector_2.12
 [exasol]: https://www.exasol.com/en/
 [spark]: https://spark.apache.org/
 [spark-ds-api]: https://databricks.com/blog/2015/01/09/spark-sql-data-sources-api-unified-data-access-for-the-spark-platform.html

--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,8 @@ lazy val orgSettings = Seq(
 )
 
 lazy val buildSettings = Seq(
-  scalaVersion := "2.12.8",
-  crossScalaVersions := Seq("2.11.12", "2.12.8")
+  scalaVersion := "2.12.10",
+  crossScalaVersions := Seq("2.11.12", "2.12.10")
 )
 
 lazy val root =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,18 +6,19 @@ import sbt._
 object Dependencies {
 
   // Versions
-  private val SparkVersion = "2.4.3"
-  private val ExasolJdbcVersion = "6.1.3"
+  private val SparkVersion = "2.4.5"
+  private val ExasolJdbcVersion = "6.2.5"
 
-  private val ScalaTestVersion = "3.0.5"
-  private val MockitoVersion = "2.23.4"
-  private val ContainersJdbcVersion = "1.10.5"
-  private val ContainersScalaVersion = "0.22.0"
+  private val ScalaTestVersion = "3.1.1"
+  private val ScalaTestMockitoVersion = "1.0.0-M2"
+  private val MockitoVersion = "3.3.3"
+  private val ContainersJdbcVersion = "1.13.0"
+  private val ContainersScalaVersion = "0.36.1"
 
   private val sparkCurrentVersion =
     sys.props.get("spark.currentVersion").getOrElse(SparkVersion)
 
-  private val SparkTestingBaseVersion = s"${sparkCurrentVersion}_0.12.0"
+  private val SparkTestingBaseVersion = s"${sparkCurrentVersion}_0.14.0"
 
   val Resolvers: Seq[Resolver] = Seq(
     "Exasol Releases" at "https://maven.exasol.com/artifactory/exasol-releases"
@@ -33,6 +34,7 @@ object Dependencies {
   /** Test dependencies only required in `test` */
   private val TestDependencies: Seq[ModuleID] = Seq(
     "org.scalatest" %% "scalatest" % ScalaTestVersion,
+    "org.scalatestplus" %% "scalatestplus-mockito" % ScalaTestMockitoVersion,
     "org.mockito" % "mockito-core" % MockitoVersion,
     "org.testcontainers" % "jdbc" % ContainersJdbcVersion,
     "com.dimafeng" %% "testcontainers-scala" % ContainersScalaVersion,

--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -3,7 +3,7 @@ package com.exasol.spark.sbt
 import sbt._
 import sbt.Keys._
 import com.typesafe.sbt.SbtGit.git
-import com.typesafe.sbt.pgp.PgpKeys._
+import com.jsuereth.sbtpgp.PgpKeys._
 import scala.xml.transform.RewriteRule
 import scala.xml.transform.RuleTransformer
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,11 +4,11 @@ addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 
 // Adds a `wartremover` a flexible Scala code linting tool
 // http://github.com/puffnfresh/wartremover
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.2")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.5")
 
 // Adds Contrib Warts
 // http://github.com/wartremover/wartremover-contrib/
-addSbtPlugin("org.wartremover" % "sbt-wartremover-contrib" % "1.3.1")
+addSbtPlugin("org.wartremover" % "sbt-wartremover-contrib" % "1.3.4")
 
 // Adds Extra Warts
 // http://github.com/danielnixon/extrawarts
@@ -28,11 +28,11 @@ addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
 
 // Adds Scala Code Coverage (Scoverage) used during unit tests
 // http://github.com/scoverage/sbt-scoverage
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 
 // Adds a `dependencyUpdates` task to check Maven repositories for dependency updates
 // http://github.com/rtimush/sbt-updates
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.4.2")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.0")
 
 // Adds a `scalafmt` task for automatic source code formatting
 // https://github.com/lucidsoftware/neo-sbt-scalafmt
@@ -48,11 +48,11 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 
 // Adds a `sonatype` release tasks
 // https://github.com/xerial/sbt-sonatype
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.2")
 
 // Adds a `gnu-pgp` plugin
 // https://github.com/sbt/sbt-pgp
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
 // Adds a `git` plugin
 // https://github.com/sbt/sbt-git

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -8,4 +8,4 @@ addSbtPlugin("com.lucidchart" % "sbt-scalafmt-coursier" % "1.16")
 
 // Used to get updates for plugins
 // see https://github.com/rtimush/sbt-updates/issues/10
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.4.1")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.0")

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -9,8 +9,8 @@ set -o errtrace -o nounset -o pipefail -o errexit
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
 cd "$BASE_DIR"
 
-MAIN_SCALA_VERSION=2.12.8
-MAIN_SPARK_VERSION=2.4.3
+MAIN_SCALA_VERSION=2.12.10
+MAIN_SPARK_VERSION=2.4.5
 
 if [[ -z "${TRAVIS_SCALA_VERSION:-}" ]]; then
   echo "Environment variable TRAVIS_SCALA_VERSION is not set"

--- a/src/it/java/org/testcontainers/containers/ExasolDockerContainer.java
+++ b/src/it/java/org/testcontainers/containers/ExasolDockerContainer.java
@@ -9,7 +9,7 @@ import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 public class ExasolDockerContainer<SELF extends ExasolDockerContainer<SELF>> extends
 JdbcDatabaseContainer<SELF> {
   public static final String EXASOL_IMAGE = "exasol/docker-db";
-  public static final String EXASOL_VERSION = "6.1.3-d1";
+  public static final String EXASOL_VERSION = "6.2.5-d1";
   public static final String EXASOL_HOST = "192.168.0.2";
   public static final Integer EXASOL_PORT = 8888;
   // wait for 5 minutes to startup

--- a/src/it/scala/com/exasol/spark/BaseDockerSuite.scala
+++ b/src/it/scala/com/exasol/spark/BaseDockerSuite.scala
@@ -70,23 +70,12 @@ trait BaseDockerSuite extends ForAllTestContainer { self: Suite =>
           |   MYBOOLEAN BOOLEAN,
           |   MYDATE DATE,
           |   MYTIMESTAMP TIMESTAMP,
-          |   MYGEOMETRY Geometry
+          |   MYGEOMETRY Geometry,
+          |   MYINTERVAL INTERVAL YEAR TO MONTH
           |)""".stripMargin,
       "commit"
     )
     exaManager.withExecute(queries)
   }
-
-  def createTypesNotCoveredTable(): Unit =
-    exaManager.withExecute(
-      Seq(
-        s"DROP SCHEMA IF EXISTS $EXA_SCHEMA CASCADE",
-        s"CREATE SCHEMA $EXA_SCHEMA",
-        s"""|CREATE OR REPLACE TABLE $EXA_SCHEMA.$EXA_TYPES_NOT_COVERED_TABLE (
-            |   myInterval INTERVAL YEAR TO MONTH
-            |)""".stripMargin,
-        "commit"
-      )
-    )
 
 }

--- a/src/it/scala/com/exasol/spark/ColumnPruningSuite.scala
+++ b/src/it/scala/com/exasol/spark/ColumnPruningSuite.scala
@@ -1,10 +1,10 @@
 package com.exasol.spark
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 /** Test only required columns selection from queries */
-class ColumnPruningSuite extends FunSuite with BaseDockerSuite with DataFrameSuiteBase {
+class ColumnPruningSuite extends AnyFunSuite with BaseDockerSuite with DataFrameSuiteBase {
 
   test("returns only required columns in query") {
     createDummyTable()

--- a/src/it/scala/com/exasol/spark/ExasolDockerContainerSuite.scala
+++ b/src/it/scala/com/exasol/spark/ExasolDockerContainerSuite.scala
@@ -3,9 +3,9 @@ package com.exasol.spark
 import java.sql.DriverManager
 import java.sql.SQLException
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class ExasolDockerContainerSuite extends FunSuite with BaseDockerSuite {
+class ExasolDockerContainerSuite extends AnyFunSuite with BaseDockerSuite {
 
   test("exasol/docker-db container should be started") {
     Class.forName(container.driverClassName) // scalastyle:ignore classForName

--- a/src/it/scala/com/exasol/spark/LoadSuite.scala
+++ b/src/it/scala/com/exasol/spark/LoadSuite.scala
@@ -5,10 +5,10 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types._
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 /** Tests for loading data from Exasol query as dataframes using short and long source formats */
-class LoadSuite extends FunSuite with BaseDockerSuite with DataFrameSuiteBase {
+class LoadSuite extends AnyFunSuite with BaseDockerSuite with DataFrameSuiteBase {
 
   test("runs dataframe show action successfully") {
     createDummyTable()

--- a/src/it/scala/com/exasol/spark/PredicatePushdownSuite.scala
+++ b/src/it/scala/com/exasol/spark/PredicatePushdownSuite.scala
@@ -5,10 +5,10 @@ import java.sql.Timestamp
 import org.apache.spark.sql.functions.col
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 /** Test where clause generation for user queries */
-class PredicatePushdownSuite extends FunSuite with BaseDockerSuite with DataFrameSuiteBase {
+class PredicatePushdownSuite extends AnyFunSuite with BaseDockerSuite with DataFrameSuiteBase {
 
   test("with where clause build from filters: filter") {
     createDummyTable()

--- a/src/it/scala/com/exasol/spark/ReservedKeywordsSuite.scala
+++ b/src/it/scala/com/exasol/spark/ReservedKeywordsSuite.scala
@@ -1,10 +1,10 @@
 package com.exasol.spark
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 /** Tests for quering an Exasol tables with reserved keywords */
-class ReservedKeywordsSuite extends FunSuite with BaseDockerSuite with DataFrameSuiteBase {
+class ReservedKeywordsSuite extends AnyFunSuite with BaseDockerSuite with DataFrameSuiteBase {
 
   val SCHEMA: String = "RESERVED_KEYWORDS"
   val TABLE: String = "TEST_TABLE"

--- a/src/it/scala/com/exasol/spark/SaveSuite.scala
+++ b/src/it/scala/com/exasol/spark/SaveSuite.scala
@@ -5,10 +5,10 @@ import java.sql.Date
 import com.exasol.spark.util.Types
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 /** Integration tests for saving Spark dataframes into Exasol tables */
-class SaveSuite extends FunSuite with BaseDockerSuite with DataFrameSuiteBase {
+class SaveSuite extends AnyFunSuite with BaseDockerSuite with DataFrameSuiteBase {
 
   test("`tableExists` should return correct boolean result") {
     createDummyTable()

--- a/src/it/scala/com/exasol/spark/TypesSuite.scala
+++ b/src/it/scala/com/exasol/spark/TypesSuite.scala
@@ -2,9 +2,9 @@ package com.exasol.spark
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
 import org.apache.spark.sql.types._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TypesSuite extends FunSuite with BaseDockerSuite with DataFrameSuiteBase {
+class TypesSuite extends AnyFunSuite with BaseDockerSuite with DataFrameSuiteBase {
 
   test("converts Exasol types to Spark") {
     createAllTypesTable()
@@ -33,32 +33,14 @@ class TypesSuite extends FunSuite with BaseDockerSuite with DataFrameSuiteBase {
       "MYBOOLEAN" -> BooleanType,
       "MYDATE" -> DateType,
       "MYTIMESTAMP" -> TimestampType,
-      "MYGEOMETRY" -> StringType
+      "MYGEOMETRY" -> StringType,
+      "MYINTERVAL" -> StringType
     )
 
     val fields = schemaTest.toList
     fields.foreach(field => {
       assert(field.dataType === schemaExpected.get(field.name).get)
     })
-  }
-
-  test("throws Exception when Exasol Type not covnverted to Spark") {
-    createTypesNotCoveredTable()
-
-    val thrown = intercept[IllegalArgumentException] {
-      val df = spark.read
-        .format("com.exasol.spark")
-        .option("host", container.host)
-        .option("port", s"${container.port}")
-        .option("query", s"SELECT * FROM $EXA_SCHEMA.$EXA_TYPES_NOT_COVERED_TABLE")
-        .load()
-      df.schema.foreach(_.dataType)
-    }
-
-    assert(
-      thrown.getMessage.contains("Received an unsupported SQL type")
-    )
-
   }
 
 }

--- a/src/test/scala/com/exasol/spark/DefaultSourceSuite.scala
+++ b/src/test/scala/com/exasol/spark/DefaultSourceSuite.scala
@@ -7,10 +7,11 @@ import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.SQLContext
 
 import org.mockito.Mockito.when
-import org.scalatest.{FunSuite, Matchers}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 
-class DefaultSourceSuite extends FunSuite with Matchers with MockitoSugar {
+class DefaultSourceSuite extends AnyFunSuite with Matchers with MockitoSugar {
 
   test("when reading should throw an Exception if no `query` parameter is provided") {
     val sqlContext = mock[SQLContext]

--- a/src/test/scala/com/exasol/spark/ExasolRelationSuite.scala
+++ b/src/test/scala/com/exasol/spark/ExasolRelationSuite.scala
@@ -9,12 +9,12 @@ import com.exasol.spark.util.ExasolConnectionManager
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
 import org.mockito.Mockito._
-import org.scalatest.FunSuite
-import org.scalatest.Matchers
-import org.scalatest.mockito.MockitoSugar
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 
 class ExasolRelationSuite
-    extends FunSuite
+    extends AnyFunSuite
     with Matchers
     with MockitoSugar
     with DataFrameSuiteBase {

--- a/src/test/scala/com/exasol/spark/rdd/ExasolRDDSuite.scala
+++ b/src/test/scala/com/exasol/spark/rdd/ExasolRDDSuite.scala
@@ -10,11 +10,11 @@ import com.exasol.jdbc.EXAResultSet
 import com.exasol.spark.util.ExasolConnectionManager
 
 import org.mockito.Mockito._
-import org.scalatest.FunSuite
-import org.scalatest.Matchers
-import org.scalatest.mockito.MockitoSugar
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 
-class ExasolRDDSuite extends FunSuite with Matchers with MockitoSugar {
+class ExasolRDDSuite extends AnyFunSuite with Matchers with MockitoSugar {
 
   test("`getPartitions` returns correct set of partitions") {
     val sparkContext = mock[SparkContext]

--- a/src/test/scala/com/exasol/spark/util/ExasolConfigurationSuite.scala
+++ b/src/test/scala/com/exasol/spark/util/ExasolConfigurationSuite.scala
@@ -1,9 +1,9 @@
 package com.exasol.spark.util
 
-import org.scalatest.FunSuite
-import org.scalatest.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class ExasolConfigurationSuite extends FunSuite with Matchers {
+class ExasolConfigurationSuite extends AnyFunSuite with Matchers {
 
   val validIPv4Addresses: Seq[String] = Seq(
     "1.1.1.1",

--- a/src/test/scala/com/exasol/spark/util/FiltersSuite.scala
+++ b/src/test/scala/com/exasol/spark/util/FiltersSuite.scala
@@ -5,11 +5,11 @@ import org.apache.spark.sql.types._
 
 import com.exasol.spark.util.Filters._
 
-import org.scalatest.FunSuite
-import org.scalatest.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
-class FiltersSuite extends FunSuite with Matchers {
+class FiltersSuite extends AnyFunSuite with Matchers {
 
   val inValues: Array[Any] = Array(1, 2, 3)
 

--- a/src/test/scala/com/exasol/spark/util/TypesSuite.scala
+++ b/src/test/scala/com/exasol/spark/util/TypesSuite.scala
@@ -4,9 +4,10 @@ import org.apache.spark.sql.types._
 
 import com.exasol.spark.util.Types._
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class TypesSuite extends FunSuite with Matchers {
+class TypesSuite extends AnyFunSuite with Matchers {
 
   test("test of Spark Decimal types to Exasol Decimal types") {
     assert(exasolTypeFromSparkDataType(DecimalType.apply(5, 2)) === "DECIMAL(5,2)")


### PR DESCRIPTION
Updates main dependencies, Spark and Exasol, to the latest versions. In
this Spark version, the `INTERVAL YEAR TO MONTH` type is supported as an
Spark `StringType`.

Additionally, updates other dependencies and plugin versions to their
respective latest versions.

Adds separate dependency for the `MockitoSugar` from scalatest-plus
library.

Fixes #62.